### PR TITLE
Add endpoint config for s3

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -36,3 +36,5 @@ strategy:
         region: S3_REGION
         # Amazon S3 bucket that you have write access to
         bucket: S3_BUCKET
+        # Custom endpoint for Amazon S3 compatible storage
+        endpoint: S3_ENDPOINT


### PR DESCRIPTION
catbox-s3 now supports a custom endpoint for S3. fhemberger/catbox-s3#53
This PR adds `endpoint` config to use S3 compatible storages.