### PR TITLE
feat(468): enable cors for ui

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+
 'use strict';
 
 const winston = require('winston');
@@ -6,18 +7,21 @@ const config = require('config');
 
 // Setup Caching strategy
 const strategyConfig = config.get('strategy');
+// eslint-disable-next-line import/no-dynamic-require
 const strategy = require(`catbox-${strategyConfig.plugin}`);
 const cache = Object.assign({ engine: strategy }, strategyConfig[strategyConfig.plugin]);
 
 const httpd = config.get('httpd');
 const auth = config.get('auth');
 const builds = config.get('builds');
+const ecosystem = config.get('ecosystem');
 
 require('../')({
     cache,
     httpd,
     builds,
-    auth
+    auth,
+    ecosystem
 }, (err, server) => {
     if (err) {
         winston.error(err);

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -40,3 +40,6 @@ strategy:
         bucket: S3_BUCKET
         # Custom endpoint for Amazon S3 compatible storage
         endpoint: S3_ENDPOINT
+
+ecosystem:
+    ui: ECOSYSTEM_UI

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -50,3 +50,6 @@ strategy:
         region: YOUR-REGION
         # Amazon S3 bucket that you have write access to
         bucket: YOUR-BUCKET-ID
+
+ecosystem:
+    ui: https://cd.screwdriver.cd

--- a/lib/server.js
+++ b/lib/server.js
@@ -31,10 +31,16 @@ const CUSTOM_PLUGINS = [
  * @return {http.Server}                            A listener: NodeJS http.Server object
  */
 module.exports = (config, callback) => {
+    // Allow ui to query store
+    const cors = {
+        origin: [config.ecosystem.ui]
+    };
+
     // Create a server with a host and port
     const server = new Hapi.Server({
         connections: {
             routes: {
+                cors,
                 log: true
             },
             router: {

--- a/test/lib/server.test.js
+++ b/test/lib/server.test.js
@@ -7,6 +7,10 @@ describe('server case', function () {
     // Time not important. Only life important.
     this.timeout(5000);
 
+    const ecosystem = {
+        ui: 'http://example.com'
+    };
+
     let hapiEngine;
 
     beforeEach(() => {
@@ -28,7 +32,8 @@ describe('server case', function () {
                 cache: { engine },
                 auth: {
                     jwtPublicKey: '12345'
-                }
+                },
+                ecosystem
             }, (e, s) => {
                 const server = s;
 
@@ -38,9 +43,13 @@ describe('server case', function () {
 
                 return server.inject({
                     method: 'GET',
-                    url: '/blah'
+                    url: '/v1/status',
+                    headers: {
+                        origin: ecosystem.ui
+                    }
                 }, (response) => {
-                    Assert.equal(response.statusCode, 404);
+                    Assert.equal(response.headers['access-control-allow-origin'], ecosystem.ui);
+                    Assert.equal(response.statusCode, 200);
                     Assert.include(response.request.info.host, '12347');
                     done();
                 });
@@ -54,7 +63,8 @@ describe('server case', function () {
                 httpd: {
                     port: 12347
                 },
-                cache: { engine }
+                cache: { engine },
+                ecosystem
             }, (error) => {
                 Assert.isOk(error);
                 done();


### PR DESCRIPTION
Enable cors for UI, so that UI can get the artifact manifest.

Related to https://github.com/screwdriver-cd/screwdriver/issues/468
