### PR TITLE
fix: Vendor updated `catbox-s3` module

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 node_modules/
 artifacts/
 features/*.feature
+vendor/*

--- a/bin/server
+++ b/bin/server
@@ -7,8 +7,14 @@ const config = require('config');
 
 // Setup Caching strategy
 const strategyConfig = config.get('strategy');
+let strategyModule = `catbox-${strategyConfig.plugin}`;
+
+// Use the vendor package until resolution of PR https://github.com/fhemberger/catbox-s3/pull/55
+if (strategyConfig.plugin === 's3') {
+    strategyModule = `../vendor/${strategyModule}`;
+}
 // eslint-disable-next-line import/no-dynamic-require
-const strategy = require(`catbox-${strategyConfig.plugin}`);
+const strategy = require(strategyModule);
 const cache = Object.assign({ engine: strategy }, strategyConfig[strategyConfig.plugin]);
 
 const httpd = config.get('httpd');

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -40,6 +40,8 @@ strategy:
         bucket: S3_BUCKET
         # Custom endpoint for Amazon S3 compatible storage
         endpoint: S3_ENDPOINT
+        # Specific signature version for KMS encrypted objects
+        signatureVersion: S3_SIG_VER
 
 ecosystem:
     ui: ECOSYSTEM_UI

--- a/vendor/catbox-s3/LICENSE.txt
+++ b/vendor/catbox-s3/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014-2015 Frederic Hemberger
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/catbox-s3/README.md
+++ b/vendor/catbox-s3/README.md
@@ -1,0 +1,80 @@
+# catbox-s3
+
+Amazon S3 adapter for [catbox](https://github.com/hapijs/catbox).
+
+[![Build Status](https://travis-ci.org/fhemberger/catbox-s3.svg?branch=master)](http://travis-ci.org/fhemberger/catbox-s3) ![Current Version](https://img.shields.io/npm/v/catbox-s3.svg)
+
+### Options
+
+- `bucket` - the S3 bucket. You need to have write access for it.
+- `accessKeyId` - the Amazon access key.
+- `secretAccessKey` - the Amazon secret access key.
+- `region` - the Amazon S3 region. (If you don't specify a region, the bucket will be created in US Standard.)
+- `endpoint` - the S3 endpoint URL. (If you don't specify an endpoint, the bucket will be created at Amazon S3 using the provided region if any)
+- `setACL` - defaults to true, if set to false, not acl is set for the objects
+- `ACL` - the ACL to set if setACL is not false, defaults to `public-read`
+
+
+### Caching binary data
+
+At the moment, Hapi doesn't support caching of non-JSONifiable responses (like Streams or Buffers, see [#1948](https://github.com/hapijs/hapi/issues/1948)).
+If you want to use catbox-s3 for binary data, you have to handle it manually in your request handler:
+
+```javascript
+var Catbox = require('catbox');
+
+// On hapi server initialization:
+// 1) Create a new catbox client instance
+var cache  = new Catbox.Client(require('catbox-s3'), {
+    accessKeyId     : /* ... */,
+    secretAccessKey : /* ... */,
+    region          : /* ... (optional) */,
+    bucket          : /* ... */
+});
+
+// 2) Inititalize the caching
+cache.start(function (err) {
+
+    if (err) { console.error(err); }
+    /* ... */
+});
+
+// Your route's request handler
+var handler = function (request, reply) {
+
+    var cacheKey = {
+        id      : /* cache item id */,
+        segment : /* cache segment name */
+    };
+
+    cache.get(cacheKey, function (err, result) {
+
+        if (result) {
+            return reply(result.item).type(/* response content type */);
+        }
+
+        yourBusinessLogic(function (err, data) {
+
+            cache.set(cacheKey, data, /* expiration in ms */, function (err) {
+
+                /* ... */
+            });
+            reply(result.item).type(/* response content type */);
+        });
+    });
+};
+
+```
+
+### Running tests
+
+In order to run the tests, set the aforementioned options as environment variables:
+
+```shell
+S3_ACCESS_KEY=<YOURKEY> S3_SECRET_KEY=<YOURSECRET> S3_REGION=<REGION> S3_BUCKET=<YOURBUCKET> npm test
+```
+
+
+### License
+
+[MIT](LICENSE.txt)

--- a/vendor/catbox-s3/index.js
+++ b/vendor/catbox-s3/index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('./lib');

--- a/vendor/catbox-s3/lib/index.js
+++ b/vendor/catbox-s3/lib/index.js
@@ -1,0 +1,275 @@
+'use strict';
+
+// Load modules
+const Hoek = require('hoek');
+const AWS  = require('aws-sdk');
+
+
+// Declare internals
+const internals = {};
+
+internals.getStoragePathForKey = function (key) {
+
+    /* eslint-disable hapi/hapi-scope-start */
+    const convert = (str) => str
+            // Remove leading/trailing slashes
+            .replace(/(^\/|\/$)/g, '')
+            // Replace special URL characters
+            .replace(/[?&#%]/g, '~');
+    /* eslint-enable hapi/hapi-scope-start */
+
+    if (key.id) {
+        key.id = convert(key.id);
+    }
+
+    if (key.segment) {
+        key.segment = convert(key.segment);
+    }
+
+    return key.id === '' ?
+        key.segment :
+        key.segment + '/' + key.id;
+};
+
+
+internals.parseBody = function (contentType, body) {
+
+    if (contentType === 'text/plain' && Buffer.isBuffer(body)) {
+        body = body.toString();
+    }
+
+    if (contentType === 'application/json') {
+        /* eslint-disable brace-style */
+        try {
+            body = JSON.parse(body);
+        } catch (e) {}
+        /* eslint-enable brace-style */
+    }
+
+    return body;
+};
+
+
+internals.testBucketAccess = function (client, settings, callback) {
+
+    const putParams = {
+        Bucket : settings.bucket,
+        Key    : internals.getStoragePathForKey({ segment: 'catbox-s3', id: 'accesstest' }),
+        Body   : 'ok'
+    };
+
+    if (settings.setACL !== false) {
+        putParams.ACL = settings.ACL ? settings.ACL : 'public-read';
+    }
+
+    const getParams = {
+        Bucket : settings.bucket,
+        Key    : internals.getStoragePathForKey({ segment: 'catbox-s3', id: 'accesstest' })
+    };
+
+    client.putObject(putParams, (err) => {
+
+        Hoek.assert(!err, `Error writing to bucket ${settings.bucket} ${err}`);
+
+        client.getObject(getParams, (err, data) => {
+
+            Hoek.assert(!err && data.Body.toString('utf8') === 'ok', `Error reading from bucket ${settings.bucket} ${err}`);
+            callback();
+        });
+    });
+};
+
+
+exports = module.exports = internals.Connection = function S3Cache (options) {
+
+    Hoek.assert(this.constructor === internals.Connection, 'S3 cache client must be instantiated using new');
+    Hoek.assert(options && options.bucket, 'Invalid Amazon S3 bucket value');
+    Hoek.assert(options && options.accessKeyId, 'Invalid Amazon S3 accessKeyId value');
+    Hoek.assert(options && options.secretAccessKey, 'Invalid Amazon S3 secretAccessKey value');
+
+    this.settings = Hoek.clone(options || {});
+    this.client = null;
+};
+
+
+internals.Connection.prototype.start = function (callback) {
+
+    const self = this;
+
+    const clientOptions = {
+        accessKeyId     : this.settings.accessKeyId,
+        secretAccessKey : this.settings.secretAccessKey
+    };
+
+    if (this.settings.region) {
+        clientOptions.region = this.settings.region;
+    }
+
+    if (this.settings.endpoint) {
+        clientOptions.endpoint = this.settings.endpoint;
+    }
+
+    if (this.settings.signatureVersion) {
+        clientOptions.signatureVersion = this.settings.signatureVersion;
+    }
+
+    this.client = new AWS.S3(clientOptions);
+
+    internals.testBucketAccess(this.client, this.settings, (err, data) => {
+
+        if (err) {
+            self.isConnected = false;
+            return callback(err);
+        }
+
+        self.isConnected = true;
+        callback();
+    });
+};
+
+
+internals.Connection.prototype.stop = function () {
+
+    if (this.client) {
+        this.client = null;
+        this.isConnected = false;
+    }
+};
+
+
+internals.Connection.prototype.isReady = function () {
+
+    return this.isConnected;
+};
+
+
+internals.Connection.prototype.validateSegmentName = function (name) {
+
+    if (!name) {
+        return new Error('Empty string');
+    }
+
+    if (name.indexOf('\0') !== -1) {
+        return new Error('Includes null character');
+    }
+
+    if (name.length < 3 || name.length > 63) {
+        return new Error('Must be between 3 and 63 characters');
+    }
+
+    return null;
+};
+
+
+internals.Connection.prototype.get = function (key, callback) {
+
+    if (!this.isConnected) {
+        return callback(new Error('Connection not started'));
+    }
+
+    const params = {
+        Bucket : this.settings.bucket,
+        Key    : internals.getStoragePathForKey(key)
+    };
+
+    this.client.getObject(params, (err, data) => {
+
+        if (err) {
+            return callback(null, null);
+        }
+
+        const now    = new Date().getTime();
+        const stored = new Date(data.Metadata['catbox-stored']);
+        let ttl      = Number(data.Metadata['catbox-ttl']) || 0;
+
+        // Calculate remaining ttl
+        ttl = (stored.getTime() + ttl) - now;
+
+        // Cache item has expired
+        if (ttl <= 0) {
+            return callback(null, null);
+        }
+
+        const result = {
+            item   : internals.parseBody(data.ContentType, data.Body),
+            stored : stored,
+            ttl    : ttl
+        };
+
+        callback(null, result);
+
+    });
+};
+
+
+internals.Connection.prototype.set = function (key, value, ttl, callback) {
+
+    if (!this.isConnected) {
+        return callback(new Error('Connection not started'));
+    }
+
+    let type = 'application/octet-stream';
+
+    if (['String', 'Number', 'Boolean'].indexOf(value.constructor.name) > -1) {
+        type = 'text/plain';
+    }
+
+    if (['Object', 'Array'].indexOf(value.constructor.name) > -1) {
+        /* eslint-disable brace-style */
+        try {
+            value = JSON.stringify(value);
+            type = 'application/json';
+        } catch (e) {
+            return callback(new Error('Could not convert object to JSON'));
+        }
+        /* eslint-enable brace-style */
+    }
+
+    const now = new Date();
+    const params = {
+        Bucket      : this.settings.bucket,
+        Key         : internals.getStoragePathForKey(key),
+        Expires     : new Date(now.getTime() + ttl),
+        ContentType : type,
+        Body        : value
+    };
+
+    if (this.settings.setACL !== false) {
+        params.ACL = this.settings.ACL ? this.settings.ACL : 'public-read';
+    }
+
+    const req = this.client.putObject(params);
+    req.on('build', () => {
+
+        req.httpRequest.headers['x-amz-meta-catbox-stored'] = now;
+        req.httpRequest.headers['x-amz-meta-catbox-ttl']    = ttl;
+    });
+    req.send((err) => {
+
+        if (err) {
+            return callback(err);
+        }
+        callback();
+    });
+};
+
+
+internals.Connection.prototype.drop = function (key, callback) {
+
+    if (!this.isConnected) {
+        return callback(new Error('Connection not started'));
+    }
+
+    const params = {
+        Bucket : this.settings.bucket,
+        Key    : internals.getStoragePathForKey(key)
+    };
+
+    this.client.deleteObject(params, (err) => {
+
+        if (err) {
+            return callback(err);
+        }
+        callback();
+    });
+};

--- a/vendor/catbox-s3/package-lock.json
+++ b/vendor/catbox-s3/package-lock.json
@@ -1,0 +1,56 @@
+{
+  "name": "catbox-s3",
+  "version": "2.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "aws-sdk": {
+      "version": "2.4.14",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.4.14.tgz",
+      "integrity": "sha1-aL//cGzd98s4o1YXmZmH5jecWEM=",
+      "requires": {
+        "jmespath": "0.15.0",
+        "sax": "1.1.5",
+        "xml2js": "0.4.15",
+        "xmlbuilder": "2.6.2"
+      }
+    },
+    "hoek": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
+    "lodash": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.5.0.tgz",
+      "integrity": "sha1-Gbs/TVEnjwuMgY7RRcdOz5/kDm0="
+    },
+    "sax": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.5.tgz",
+      "integrity": "sha1-HaUKjQDN7NWUBWWfX/hTSf53N0M="
+    },
+    "xml2js": {
+      "version": "0.4.15",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.15.tgz",
+      "integrity": "sha1-lc0D/y3RROwovGJzvysokMWBrQw=",
+      "requires": {
+        "sax": "1.1.5",
+        "xmlbuilder": "2.6.2"
+      }
+    },
+    "xmlbuilder": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.6.2.tgz",
+      "integrity": "sha1-+Rb20Q1F3BcbG+Lm5nP7bgzDXQo=",
+      "requires": {
+        "lodash": "3.5.0"
+      }
+    }
+  }
+}

--- a/vendor/catbox-s3/package.json
+++ b/vendor/catbox-s3/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "catbox-s3",
+  "description": "Amazon S3 adapter for catbox",
+  "version": "2.1.0",
+  "author": "Frederic Hemberger (https://frederic-hemberger.de)",
+  "main": "index.js",
+  "scripts": {
+    "lab": "NODE_ENV=test node node_modules/.bin/lab -L --timeout 5000 --lint-warnings-threshold 99999",
+    "test": "npm run lab -- test/index.js",
+    "coverage": "npm run lab -- -c",
+    "coverage:html": "npm run coverage -- -r html -o coverage.html"
+  },
+  "files": [
+    "lib",
+    "index.js"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/fhemberger/catbox-s3"
+  },
+  "keywords": [
+    "amazon",
+    "aws",
+    "cache",
+    "catbox",
+    "s3"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/fhemberger/catbox-s3/issues"
+  },
+  "homepage": "https://github.com/fhemberger/catbox-s3",
+  "dependencies": {
+    "aws-sdk": "2.4.x",
+    "hoek": "4.x.x"
+  },
+  "devDependencies": {
+    "catbox": "7.x.x",
+    "code": "3.x.x",
+    "eslint-config-hapi": "9.x.x",
+    "eslint-plugin-hapi": "4.x.x",
+    "lab": "10.x.x"
+  }
+}

--- a/vendor/catbox-s3/test/.eslintrc
+++ b/vendor/catbox-s3/test/.eslintrc
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    "max-nested-callbacks": [2, 8],
+    "no-unused-vars": 1
+  }
+}

--- a/vendor/catbox-s3/test/index.js
+++ b/vendor/catbox-s3/test/index.js
@@ -1,0 +1,674 @@
+'use strict';
+
+// Load modules
+const Lab = require('lab');
+const Code = require('code');
+const Catbox = require('catbox');
+const S3 = require('..');
+
+
+const options = {
+    accessKeyId     : process.env.S3_ACCESS_KEY,
+    secretAccessKey : process.env.S3_SECRET_KEY,
+    bucket          : process.env.S3_BUCKET,
+    setACL          : process.env.S3_SET_ACL && process.env.S3_SET_ACL === 'false' ? false : true
+};
+
+if (process.env.S3_REGION) {
+    options.region = process.env.S3_REGION;
+}
+
+if (process.env.S3_ENDPOINT) {
+    options.endpoint = process.env.S3_ENDPOINT;
+}
+
+
+// Test shortcuts
+const lab = exports.lab = Lab.script();
+const describe = lab.describe;
+const it = lab.it;
+const expect = Code.expect;
+
+
+describe('S3', () => {
+
+    it('throws an error if not created with new', (done) => {
+
+        const fn = () => {
+
+            S3();
+        };
+
+        expect(fn).to.throw(Error);
+        done();
+    });
+
+
+    it('creates a new connection', (done) => {
+
+        const client = new Catbox.Client(S3, options);
+        client.start((err) => {
+
+            expect(err).to.not.exist();
+            expect(client.isReady()).to.equal(true);
+            done();
+        });
+    });
+
+    it('closes the connection', (done) => {
+
+        const client = new Catbox.Client(S3, options);
+        client.start((err) => {
+
+            expect(err).to.not.exist();
+            expect(client.isReady()).to.equal(true);
+            client.stop();
+            expect(client.isReady()).to.equal(false);
+            done();
+        });
+    });
+
+
+    it('gets an item after setting it', (done) => {
+
+        const client = new Catbox.Client(S3, options);
+        client.start((err) => {
+
+            expect(err).to.not.exist();
+            const key = { id: 'test/id?with special%chars&', segment: 'test' };
+            client.set(key, '123', 5000, (err) => {
+
+                expect(err).to.not.exist();
+                client.get(key, (err, result) => {
+
+                    expect(err).to.equal(null);
+                    expect(result.item).to.equal('123');
+                    done();
+                });
+            });
+        });
+    });
+
+
+    it('buffers can be set and retrieved', (done) => {
+
+        const buffer = new Buffer('string value');
+        const client = new Catbox.Client(new S3(options));
+
+        client.start((err) => {
+
+            expect(err).to.not.exist();
+            const key = { id: 'buffer', segment: 'test' };
+
+            client.set(key, buffer, 2000, (err) => {
+
+                expect(err).to.not.exist();
+                client.get(key, (err, result) => {
+
+                    expect(err).to.not.exist();
+                    expect(result.item instanceof Buffer).to.equal(true);
+                    expect(result.item).to.equal(buffer);
+                    done();
+                });
+            });
+        });
+    });
+
+
+    it('buffers are copied before storing', (done) => {
+
+        const buffer = new Buffer('string value');
+        const client = new Catbox.Client(new S3(options));
+
+        client.start((err) => {
+
+            expect(err).to.not.exist();
+            const key = { id: 'buffer-copied', segment: 'test' };
+            client.set(key, buffer, 2000, (err) => {
+
+                expect(err).to.not.exist();
+                client.get(key, (err, result) => {
+
+                    expect(err).to.not.exist();
+                    expect(result.item).to.not.shallow.equal(buffer);
+                    done();
+                });
+            });
+        });
+    });
+
+
+    it('fails setting an item circular references', (done) => {
+
+        const client = new Catbox.Client(S3, options);
+        client.start((err) => {
+
+            expect(err).to.not.exist();
+            const key = { id: 'circular', segment: 'test' };
+            const value = { a: 1 };
+            value.b = value;
+
+            client.set(key, value, 10, (err) => {
+
+                expect(err.message).to.equal('Could not convert object to JSON');
+                done();
+            });
+        });
+    });
+
+
+    it('ignored starting a connection twice on same event', (done) => {
+
+        let x = 2;
+        const client = new Catbox.Client(S3, options);
+        const start = () => {
+
+            client.start((err) => {
+
+                expect(err).to.not.exist();
+                expect(client.isReady()).to.equal(true);
+                --x;
+                if (!x) {
+                    done();
+                }
+            });
+        };
+
+        start();
+        start();
+    });
+
+
+    it('ignored starting a connection twice chained', (done) => {
+
+        const client = new Catbox.Client(S3, options);
+        client.start((err) => {
+
+            expect(err).to.not.exist();
+            expect(client.isReady()).to.equal(true);
+            client.start((err) => {
+
+                expect(err).to.not.exist();
+                expect(client.isReady()).to.equal(true);
+                done();
+            });
+        });
+    });
+
+
+    it('returns not found on get when using null key', (done) => {
+
+        const client = new Catbox.Client(S3, options);
+        client.start((err) => {
+
+            expect(err).to.not.exist();
+            client.get(null, (err, result) => {
+
+                expect(err).to.equal(null);
+                expect(result).to.equal(null);
+                done();
+            });
+        });
+    });
+
+
+    it('returns not found on get when item expired', (done) => {
+
+        const client = new Catbox.Client(S3, options);
+        client.start((err) => {
+
+            expect(err).to.not.exist();
+            const key = { id: 'x', segment: 'test' };
+            client.set(key, 'x', 1, (err) => {
+
+                expect(err).to.not.exist();
+                setTimeout(() => {
+
+                    client.get(key, (err, result) => {
+
+                        expect(err).to.equal(null);
+                        expect(result).to.equal(null);
+                        done();
+                    });
+                }, 1000);
+            });
+        });
+    });
+
+
+    it('errors on set when using null key', (done) => {
+
+        const client = new Catbox.Client(S3, options);
+        client.start((err) => {
+
+            expect(err).to.not.exist();
+            client.set(null, {}, 1000, (err) => {
+
+                expect(err instanceof Error).to.equal(true);
+                done();
+            });
+        });
+    });
+
+
+    it('errors on get when using invalid key', (done) => {
+
+        const client = new Catbox.Client(S3, options);
+        client.start((err) => {
+
+            expect(err).to.not.exist();
+            client.get({}, (err) => {
+
+                expect(err instanceof Error).to.equal(true);
+                done();
+            });
+        });
+    });
+
+
+    it('errors on set when using invalid key', (done) => {
+
+        const client = new Catbox.Client(S3, options);
+        client.start((err) => {
+
+            expect(err).to.not.exist();
+            client.set({}, {}, 1000, (err) => {
+
+                expect(err instanceof Error).to.equal(true);
+                done();
+            });
+        });
+    });
+
+
+    it('ignores set when using non-positive ttl value', (done) => {
+
+        const client = new Catbox.Client(S3, options);
+        client.start((err) => {
+
+            expect(err).to.not.exist();
+            const key = { id: 'x', segment: 'test' };
+            client.set(key, 'y', 0, (err) => {
+
+                expect(err).to.not.exist();
+                done();
+            });
+        });
+    });
+
+
+    it('errors on get when stopped', (done) => {
+
+        const client = new Catbox.Client(S3, options);
+        client.stop();
+        const key = { id: 'x', segment: 'test' };
+        client.connection.get(key, (err, result) => {
+
+            expect(err).to.exist;
+            expect(result).to.not.exist;
+            done();
+        });
+    });
+
+
+    it('errors on set when stopped', (done) => {
+
+        const client = new Catbox.Client(S3, options);
+        client.stop();
+        const key = { id: 'x', segment: 'test' };
+        client.connection.set(key, 'y', 1, (err) => {
+
+            expect(err).to.exist;
+            done();
+        });
+    });
+
+
+    it('errors on missing segment name', (done) => {
+
+        const config = {
+            expiresIn: 50000
+        };
+
+        const fn = () => {
+
+            const client = new Catbox.Client(S3, options);
+            new Catbox.Policy(config, client, '');
+        };
+        expect(fn).to.throw(Error);
+        done();
+    });
+
+
+    it('errors on bad segment name', (done) => {
+
+        const config = {
+            expiresIn: 50000
+        };
+        const fn = () => {
+
+            const client = new Catbox.Client(S3, options);
+            new Catbox.Policy(config, client, 'a\0b');
+        };
+        expect(fn).to.throw(Error);
+        done();
+    });
+
+
+    it('supports empty keys', (done) => {
+
+        const client = new Catbox.Client(S3, options);
+        client.start((err) => {
+
+            expect(err).to.not.exist();
+
+            const key = { id: '', segment: 'test' };
+            client.set(key, '123', 5000, (err) => {
+
+                expect(err).to.not.exist();
+                client.get(key, (err, result) => {
+
+                    expect(err).to.not.exist();
+                    expect(result.item).to.equal('123');
+                    done();
+                });
+            });
+        });
+    });
+
+
+    describe('#start', () => {
+
+        it('creates an empty client object', (done) => {
+
+            const s3 = new S3(options);
+            expect(s3.client).to.not.exist;
+            s3.start(() => {
+
+                expect(s3.client).to.exist;
+                done();
+            });
+        });
+
+    });
+
+    describe('#stop', () => {
+
+        it('sets the cache client to null', (done) => {
+
+            const s3 = new S3(options);
+            expect(s3.client).to.not.exist;
+            s3.start(() => {
+
+                expect(s3.client).to.exist;
+                s3.stop();
+                expect(s3.client).to.not.exist;
+                done();
+            });
+        });
+
+    });
+
+    describe('#get', () => {
+
+        it('returns not found on missing segment', (done) => {
+
+            const key = {
+                segment : 'unknownsegment',
+                id      : 'test'
+            };
+            const s3 = new S3(options);
+            expect(s3.client).to.not.exist;
+            s3.start(() => {
+
+                expect(s3.client).to.exist;
+                s3.get(key, (err, result) => {
+
+                    expect(err).to.not.exist();
+                    expect(result).to.not.exist;
+                    done();
+                });
+            });
+        });
+    });
+
+
+    describe('#set', () => {
+
+        it('adds an item to the cache object', (done) => {
+
+            const key = {
+                segment : 'test',
+                id      : 'test'
+            };
+
+            const s3 = new S3(options);
+            expect(s3.client).to.not.exist;
+
+            s3.start(() => {
+
+                expect(s3.client).to.exist;
+                s3.set(key, 'myvalue', 2000, () => {
+
+                    s3.get(key, (err, result) => {
+
+                        expect(err).to.not.exist();
+                        expect(result.item).to.equal('myvalue');
+                        done();
+                    });
+                });
+            });
+        });
+
+        it('removes an item from the cache object when it expires', (done) => {
+
+            const key = {
+                segment: 'test',
+                id: 'test'
+            };
+
+            const s3 = new S3(options);
+            expect(s3.client).to.not.exist;
+            s3.start(() => {
+
+                expect(s3.client).to.exist;
+                s3.set(key, 'myvalue', 2000, () => {
+
+                    s3.get(key, (err, result) => {
+
+                        expect(err).to.not.exist();
+                        expect(result.item).to.equal('myvalue');
+                        setTimeout(() => {
+
+                            s3.get(key, (err, result) => {
+
+                                expect(err).to.not.exist();
+                                expect(result).to.not.exist;
+                                done();
+                            });
+                        }, 1500);
+                    });
+                });
+            });
+        });
+    });
+
+
+    describe('#drop', () => {
+
+        it('drops an existing item', (done) => {
+
+            const client = new Catbox.Client(S3, options);
+            client.start((err) => {
+
+                expect(err).to.not.exist();
+                const key = { id: 'x', segment: 'test' };
+                client.set(key, '123', 5000, (err) => {
+
+                    expect(err).to.not.exist();
+                    client.get(key, (err, result) => {
+
+                        expect(err).to.equal(null);
+                        expect(result.item).to.equal('123');
+                        client.drop(key, (err) => {
+
+                            expect(err).to.not.exist();
+                            done();
+                        });
+                    });
+                });
+            });
+        });
+
+
+        it('drops an item from a missing segment', (done) => {
+
+            const client = new Catbox.Client(S3, options);
+            client.start((err) => {
+
+                expect(err).to.not.exist();
+                const key = { id: 'x', segment: 'test' };
+                client.drop(key, (err) => {
+
+                    expect(err).to.not.exist();
+                    done();
+                });
+            });
+        });
+
+
+        it('drops a missing item', (done) => {
+
+            const client = new Catbox.Client(S3, options);
+            client.start((err) => {
+
+                expect(err).to.not.exist();
+                const key = { id: 'x', segment: 'test' };
+                client.set(key, '123', 2000, (err) => {
+
+                    expect(err).to.not.exist();
+                    client.get(key, (err, result) => {
+
+                        expect(err).to.equal(null);
+                        expect(result.item).to.equal('123');
+                        client.drop({ id: 'y', segment: 'test' }, (err) => {
+
+                            expect(err).to.not.exist();
+                            done();
+                        });
+                    });
+                });
+            });
+        });
+
+
+        it('errors on drop when using invalid key', (done) => {
+
+            const client = new Catbox.Client(S3, options);
+            client.start((err) => {
+
+                expect(err).to.not.exist();
+                client.drop({}, (err) => {
+
+                    expect(err instanceof Error).to.equal(true);
+                    done();
+                });
+            });
+        });
+
+
+        it('errors on drop when using null key', (done) => {
+
+            const client = new Catbox.Client(S3, options);
+            client.start((err) => {
+
+                expect(err).to.not.exist();
+                client.drop(null, (err) => {
+
+                    expect(err instanceof Error).to.equal(true);
+                    done();
+                });
+            });
+        });
+
+
+        it('errors on drop when stopped', (done) => {
+
+            const client = new Catbox.Client(S3, options);
+            client.stop();
+            const key = { id: 'x', segment: 'test' };
+            client.connection.drop(key, (err) => {
+
+                expect(err).to.exist;
+                done();
+            });
+        });
+
+
+        it('errors when cache item dropped while stopped', (done) => {
+
+            const client = new Catbox.Client(S3, options);
+            client.stop();
+            client.drop('a', (err) => {
+
+                expect(err).to.exist;
+                done();
+            });
+        });
+    });
+
+
+    describe('#validateSegmentName', () => {
+
+        it('errors when the name is empty', (done) => {
+
+            const s3 = new S3(options);
+            const result = s3.validateSegmentName('');
+
+            expect(result).to.be.instanceOf(Error);
+            expect(result.message).to.equal('Empty string');
+            done();
+        });
+
+
+        it('errors when the name has a null character', (done) => {
+
+            const s3 = new S3(options);
+            const result = s3.validateSegmentName('\0test');
+
+            expect(result).to.be.instanceOf(Error);
+            done();
+        });
+
+
+        it('errors when the name has less than three characters', (done) => {
+
+            const s3 = new S3(options);
+            const result = s3.validateSegmentName('yo');
+
+            expect(result).to.be.instanceOf(Error);
+            done();
+        });
+
+
+        it('errors when the name has more than 64 characters', (done) => {
+
+            const s3 = new S3(options);
+            const result = s3.validateSegmentName('abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890');
+
+            expect(result).to.be.instanceOf(Error);
+            done();
+        });
+
+
+        it('returns null when there are no errors', (done) => {
+
+            const s3 = new S3(options);
+            const result = s3.validateSegmentName('valid');
+
+            expect(result).to.not.be.instanceOf(Error);
+            expect(result).to.equal(null);
+            done();
+        });
+    });
+});


### PR DESCRIPTION
## Context

The store is unable to interact with objects stored in an encrypted S3 bucket. This is due to a rejection from AWS for not providing the *Signature Version* along with our S3 requests.

We use `catbox-s3` to abstract the S3 interactions, which currently does not allow the user to specify the `signatureVersion` client option. By choosing to vendor a fix, we can deploy the patched version without being blocked on the upstream dependency to take in the update.

## Objective

Vendor in a patched `catbox-s3` module that will allow us to specify the *Signature Version* when interacting with an encrypted S3 bucket.

## References

* PR for upstream fix: https://github.com/fhemberger/catbox-s3/pull/55