### PR TITLE
fix: Allow tokens to be passed into the URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "good-console": "^6.2.0",
     "good-squeeze": "^5.0.0",
     "hapi": "^16.0.1",
-    "hapi-auth-jwt": "^4.0.0",
+    "hapi-auth-jwt2": "^7.3.0",
     "hapi-swagger": "^7.1.0",
     "hoek": "^4.0.2",
     "inert": "^4.0.2",

--- a/plugins/auth.js
+++ b/plugins/auth.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const jwt = require('hapi-auth-jwt');
+const jwt = require('hapi-auth-jwt2');
 const joi = require('joi');
 
 /**
@@ -28,6 +28,11 @@ exports.register = (server, options, next) => {
             verifyOptions: {
                 algorithms: ['RS256'],
                 maxAge: '12h'
+            },
+            // This function is run once the Token has been decoded with signature
+            validateFunc(decoded, request, cb) {
+                // TODO: figure out what to do here
+                cb(null, true);
             }
         });
 

--- a/test/plugins/auth.test.js
+++ b/test/plugins/auth.test.js
@@ -49,6 +49,6 @@ describe('auth plugin test', () => {
     });
 
     it('registers the plugin', () => {
-        assert.isOk(server.registrations['hapi-auth-jwt']);
+        assert.isOk(server.registrations['hapi-auth-jwt2']);
     });
 });


### PR DESCRIPTION
## Context
We would like to increase security on store endpoints. Currently, anyone can make requests to the store without a token for build artifacts. By requiring the store to take in a token, only requests made with a JWT will work against the store for artifacts. We need to allow tokens to be passed through the URL so the UI can make calls to the Store using the user's token when the user clicks on artifact links in the UI.

## Objective
This PR switches from using `hapi-auth-jwt` to `hapi-auth-jwt2`.

## Related links
- Similar PR: https://github.com/screwdriver-cd/screwdriver/pull/738
- NPM package: https://www.npmjs.com/package/hapi-auth-jwt2