### PR TITLE
fix: add path-style URL switch flag for S3 strategy.

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -42,6 +42,8 @@ strategy:
         endpoint: S3_ENDPOINT
         # Specific signature version for KMS encrypted objects
         signatureVersion: S3_SIG_VER
+        # Whether to force path style URLs for S3 objects.
+        forcePathStyle: S3_FORCE_PATH_STYLE
 
 ecosystem:
     ui: ECOSYSTEM_UI

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -50,6 +50,8 @@ strategy:
         region: YOUR-REGION
         # Amazon S3 bucket that you have write access to
         bucket: YOUR-BUCKET-ID
+        # Whether to force path style URLs for S3 objects.
+        forcePathStyle: false
 
 ecosystem:
     ui: https://cd.screwdriver.cd

--- a/vendor/catbox-s3/lib/index.js
+++ b/vendor/catbox-s3/lib/index.js
@@ -113,6 +113,10 @@ internals.Connection.prototype.start = function (callback) {
         clientOptions.signatureVersion = this.settings.signatureVersion;
     }
 
+    if (this.settings.forcePathStyle) {
+        clientOptions.s3ForcePathStyle = this.settings.forcePathStyle;
+    }
+
     this.client = new AWS.S3(clientOptions);
 
     internals.testBucketAccess(this.client, this.settings, (err, data) => {


### PR DESCRIPTION
## Context

S3 storage strategy (catbox-s3) supports **virtual-hosted-style** URL by default and does not provide a flag to use **path-style** URL.

- virtual-hosted-style: http://bucket.s3.example.com
- path-style: http://s3.example.com/bucket

## Objective

This PR adds path-style URL switch flag and makes it possible for users to use a S3 compatible server (that supports path-style only, e.g. Minio) easily.

## References

- [s3ForcePathStyle-property](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html#s3ForcePathStyle-property)