### PR TITLE
fix: Remove extra git scripts from publish job

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -15,8 +15,6 @@ jobs:
         steps:
           - postpublish: |
                 git clone https://github.com/screwdriver-cd/toolbox.git ci
-                ./ci/git-tag.sh
-                ./ci/git-release.sh
                 export DOCKER_TAG=`cat VERSION`
                 ./ci/docker-trigger.sh
         environment:

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -15,7 +15,8 @@ jobs:
         steps:
           - postpublish: |
                 git clone https://github.com/screwdriver-cd/toolbox.git ci
-                export DOCKER_TAG=`cat VERSION`
+                git fetch
+                export DOCKER_TAG=`git tag | tail -1`
                 ./ci/docker-trigger.sh
         environment:
             # Docker hub repo


### PR DESCRIPTION
Don't need those scripts anymore since we're using semantic release

## Related links
https://github.com/screwdriver-cd/toolbox/blob/master/docker-trigger.sh
https://gist.github.com/stjohnjohnson/3d2388b2a7ba658cdcdaffa8cd874e50#file-docker-sh