### PR TITLE
feat: Pull in S3 IAM fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "boom": "^4.0.0",
     "catbox": "^7.1.2",
     "catbox-memory": "^2.0.3",
-    "catbox-s3": "^3.0.0",
+    "catbox-s3": "^3.1.0",
     "config": "^1.21.0",
     "good": "^7.0.2",
     "good-console": "^6.2.0",


### PR DESCRIPTION
Grab the latest copy of the catbox-s3 plugin as it now supports [IAM roles in EC2](https://github.com/fhemberger/catbox-s3/pull/59)