### PR TITLE
fix: get latest tag

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -16,7 +16,7 @@ jobs:
           - postpublish: |
                 git clone https://github.com/screwdriver-cd/toolbox.git ci
                 git fetch
-                export DOCKER_TAG=`git tag | tail -1`
+                export DOCKER_TAG=`git describe --tags`
                 ./ci/docker-trigger.sh
         environment:
             # Docker hub repo


### PR DESCRIPTION
git tag's sorting order is alphabetical not based on the time. git describe --tags will give the latest tag instead