### PR TITLE
feat: Delete commands endpoint

### DIFF
--- a/plugins/commands.js
+++ b/plugins/commands.js
@@ -136,7 +136,7 @@ exports.register = (server, options, next) => {
             tags: ['api', 'commands'],
             auth: {
                 strategies: ['token'],
-                scope: ['user']
+                scope: ['build', 'user']
             },
             plugins: {
                 'hapi-swagger': {

--- a/plugins/commands.js
+++ b/plugins/commands.js
@@ -145,23 +145,14 @@ exports.register = (server, options, next) => {
             },
             handler: (request, reply) => {
                 const { namespace, name, version } = request.params;
-
                 const id = `${namespace}-${name}-${version}`;
 
-                cache.drop(id, (err, value) => {
+                cache.drop(id, (err) => {
                     if (err) {
                         return reply(err);
                     }
-                    if (!value) {
-                        return reply(boom.notFound());
-                    }
 
-                    // @TODO put cache headers in here
-                    const response = reply(Buffer.from(value.c.data));
-
-                    response.headers = value.h;
-
-                    return response;
+                    return reply();
                 });
             },
             validate: {

--- a/test/plugins/commands.test.js
+++ b/test/plugins/commands.test.js
@@ -197,4 +197,62 @@ describe('commands plugin test', () => {
             });
         });
     });
+
+    describe('DELETE /commands/:namespace/:name/:version', () => {
+        let options;
+
+        beforeEach(() => {
+            options = {
+                method: 'DELETE',
+                headers: {
+                    'x-foo': 'bar',
+                    'content-type': 'text/plain',
+                    ignore: 'true'
+                },
+                credentials: {
+                    scope: ['user']
+                }
+            };
+        });
+
+        it('returns 404 if not found', () => {
+            server.inject({
+                headers: {
+                    'x-foo': 'bar'
+                },
+                credentials: {
+                    scope: ['user']
+                },
+                url: `/commands/${mockCommandNamespace}/foo/0.0`
+            }).then((reply) => {
+                assert.equal(reply.statusCode, 404);
+            });
+        });
+
+        it('deletes an artifact', () => {
+            options.url = `/commands/${mockCommandNamespace}/`
+                + `${mockCommandName}/${mockCommandVersion}`;
+
+            return server.inject(options).then((reply) => {
+                assert.equal(reply.statusCode, 204);
+
+                return server.inject({
+                    url: `/commands/${mockCommandNamespace}/`
+                        + `${mockCommandName}/${mockCommandVersion}`,
+                    headers: {
+                        'x-foo': 'bar'
+                    },
+                    credentials: {
+                        scope: ['user']
+                    }
+                }).then((reply2) => {
+                    assert.equal(reply2.statusCode, 200);
+                    assert.equal(reply2.headers['x-foo'], 'bar');
+                    assert.equal(reply2.headers['content-type'], 'text/plain; charset=utf-8');
+                    assert.isNotOk(reply2.headers.ignore);
+                    assert.equal(reply2.result, 'THIS IS A TEST');
+                });
+            });
+        });
+    });
 });


### PR DESCRIPTION
# Context

We need an endpoint to be able to delete command binaries from the store.

# Objectives

- [x] Create a DELETE endpoint to delete a command binary from store based on version
- [x] Tests

# Related links

API PR to delete commands: https://github.com/screwdriver-cd/screwdriver/pull/990
UI PR to delete commands: https://github.com/screwdriver-cd/ui/pull/281