### PR TITLE
fix: increase request timeout to 60s

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -42,7 +42,8 @@ module.exports = async (config) => {
     const server = Hapi.server({
         routes: {
             cors,
-            log: { collect: true }
+            log: { collect: true },
+            payload: { timeout: 60000 }
         },
         router: {
             stripTrailingSlash: true


### PR DESCRIPTION
Increase request timeout to 60s from 10s cuz it can take a long time when uploading to S3 sometimes.
This giving 408 in the build!
