### PR TITLE
fix: sleep 10 before checking the endpoint

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -39,7 +39,7 @@ jobs:
             - get-tag: ./ci/git-latest.sh
             - wait-docker: DOCKER_TAG=`cat VERSION` ./ci/docker-wait.sh
             - deploy-k8s: K8S_TAG=`cat VERSION` ./ci/k8s-deploy.sh
-            - test: curl --silent --fail -o /dev/null https://beta.store.screwdriver.cd/v1/status
+            - test: sleep 10 && curl --silent --fail -o /dev/null https://beta.store.screwdriver.cd/v1/status
         environment:
             DOCKER_REPO: screwdrivercd/store
             K8S_CONTAINER: screwdriver-store
@@ -59,7 +59,7 @@ jobs:
             - get-tag: ./ci/git-latest.sh
             - wait-docker: DOCKER_TAG=`cat VERSION` ./ci/docker-wait.sh
             - deploy-k8s: K8S_TAG=`cat VERSION` ./ci/k8s-deploy.sh
-            - test: curl --silent --fail -o /dev/null https://store.screwdriver.cd/v1/status
+            - test: sleep 10 && curl --silent --fail -o /dev/null https://store.screwdriver.cd/v1/status
         environment:
             DOCKER_REPO: screwdrivercd/store
             K8S_CONTAINER: screwdriver-store


### PR DESCRIPTION
sleep 10 before checking the endpoint since it took sometime for the pod to be ready

Always need to rerun jobs to make it pass now: https://cd.screwdriver.cd/pipelines/24/events