### PR TITLE
fix: increase wait time to 15 sec after deployment

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -39,7 +39,7 @@ jobs:
             - get-tag: ./ci/git-latest.sh
             - wait-docker: DOCKER_TAG=`cat VERSION` ./ci/docker-wait.sh
             - deploy-k8s: K8S_TAG=`cat VERSION` ./ci/k8s-deploy.sh
-            - test: sleep 10 && curl --silent --fail -o /dev/null https://beta.store.screwdriver.cd/v1/status
+            - test: sleep 15 && curl --silent --fail -o /dev/null https://beta.store.screwdriver.cd/v1/status
         environment:
             DOCKER_REPO: screwdrivercd/store
             K8S_CONTAINER: screwdriver-store
@@ -59,7 +59,7 @@ jobs:
             - get-tag: ./ci/git-latest.sh
             - wait-docker: DOCKER_TAG=`cat VERSION` ./ci/docker-wait.sh
             - deploy-k8s: K8S_TAG=`cat VERSION` ./ci/k8s-deploy.sh
-            - test: sleep 10 && curl --silent --fail -o /dev/null https://store.screwdriver.cd/v1/status
+            - test: sleep 15 && curl --silent --fail -o /dev/null https://store.screwdriver.cd/v1/status
         environment:
             DOCKER_REPO: screwdrivercd/store
             K8S_CONTAINER: screwdriver-store


### PR DESCRIPTION
Our builds keep failing because 10 secs wait is not enough, the service is not back up. 