### PR TITLE
fix(1257): remove checksum, add tests

### DIFF
--- a/helpers/aws.js
+++ b/helpers/aws.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const AWS = require('aws-sdk');
-const crypto = require('crypto');
 
 class AwsClient {
     /**
@@ -57,34 +56,6 @@ class AwsClient {
 
                 return callback(null);
             });
-        });
-    }
-
-    /**
-     * Compare the checksum of local cache with the one in S3
-     * @method compareChecksum
-     * @param  {String}        localCache     content of localFile
-     * @param  {String}        cacheKey       cache key
-     * @param  {Function}      callback       callback function
-     */
-    compareChecksum(localCache, cacheKey, callback) {
-        const params = {
-            Bucket: this.bucket,
-            Key: cacheKey
-        };
-        const localmd5 = crypto.createHash('md5').update(localCache).digest('hex');
-
-        return this.client.headObject(params, (err, data) => {
-            if (err) {
-                return callback(err);
-            }
-            const remotemd5 = data.Metadata.md5;
-
-            if (localmd5 !== remotemd5) {
-                return callback(null, false);
-            }
-
-            return callback(null, true);
         });
     }
 }

--- a/plugins/caches.js
+++ b/plugins/caches.js
@@ -143,22 +143,7 @@ exports.plugin = {
                     + `headers ${JSON.stringify(contents.h)}`);
 
                 try {
-                    if (!awsClient) {
-                        await cache.set(cacheKey, value, 0);
-                    } else {
-                        await awsClient.compareChecksum(value.c,
-                            `caches/${cacheKey}`, async (err, areEqual) => {
-                                if (err) {
-                                    console.log('Failed to compare checksums: ', err);
-                                }
-
-                                if (!areEqual) {
-                                    await cache.set(cacheKey, value, 0);
-                                } else {
-                                    console.log('Cache has not changed, not setting cache.');
-                                }
-                            });
-                    }
+                    await cache.set(cacheKey, value, 0);
                 } catch (err) {
                     request.log([cacheName, 'error'], `Failed to store in cache: ${err}`);
 

--- a/test/helpers/aws.test.js
+++ b/test/helpers/aws.test.js
@@ -105,45 +105,4 @@ describe('aws helper test', () => {
             done();
         });
     });
-
-    it('returns true if checksum are the same', (done) => {
-        const headParam = {
-            Bucket: testBucket,
-            Key: cacheKey
-        };
-
-        return awsClient.compareChecksum(localCache, cacheKey, (err, checksum) => {
-            assert.calledWith(clientMock.prototype.headObject, headParam);
-            assert.isNull(err);
-            assert.isTrue(checksum);
-            done();
-        });
-    });
-
-    it('returns false if checksum are not the same', (done) => {
-        const headParam = {
-            Bucket: testBucket,
-            Key: cacheKey
-        };
-
-        const newLocalCache = 'A DIFFERENT FILE';
-
-        return awsClient.compareChecksum(newLocalCache, cacheKey, (err, checksum) => {
-            assert.calledWith(clientMock.prototype.headObject, headParam);
-            assert.isNull(err);
-            assert.isFalse(checksum);
-            done();
-        });
-    });
-
-    it('returns err if fails to get headObject', (done) => {
-        const err = new Error('failed to get headObject');
-
-        clientMock.prototype.headObject = sinon.stub().yieldsAsync(err);
-
-        return awsClient.compareChecksum(localCache, cacheKey, (e) => {
-            assert.deepEqual(e, err);
-            done();
-        });
-    });
 });


### PR DESCRIPTION
We will no longer compute the md5 of the zip, since zip always changes because of the `last modified` metadata in the zip file. 

Instead, we will upload a md5json file contains all md5 of files in the folder. Then we will perform the comparison in the `store-cli` to figure out whether it is necessary to upload. 

Related:
https://github.com/screwdriver-cd/store-cli/pull/11
https://github.com/screwdriver-cd/screwdriver/issues/1257
https://github.com/screwdriver-cd/screwdriver/issues/1281