### PR TITLE
fix: set accesskey default value to null

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -55,9 +55,9 @@ strategy:
         allowMixedContent: true
     s3:
         # Amazon access key
-        accessKeyId: YOUR-KEY-ID
+        accessKeyId: null
         # Amazon secret access key
-        secretAccessKey: YOUR-KEY-SECRET
+        secretAccessKey: null
         # Amazon S3 region
         region: YOUR-REGION
         # Amazon S3 bucket that you have write access to


### PR DESCRIPTION
For public accessible or role based permission model, S3 buckets do not need IAM user. Set the default value to null to avoid always passing in access key.