### PR TITLE
fix: add catbox-disk

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -38,6 +38,12 @@ commands:
 
 strategy:
     plugin: STRATEGY
+    disk:
+        # Reference for the following options: https://github.com/mirusresearch/catbox-disk
+        # existing dir to store the cache
+        cachePath: DISK_CACHE_PATH
+        # number of milliseconds between each cache cleanup for disk space recovery. Set to 0 to deactivate entirely.
+        cleanEvery: DISK_CLEAN_EVERY
     memory:
         # Upper limit on the number of bytes that can be stored in the cache
         maxByteSize: MEMORY_MAX_BYTES

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -48,6 +48,12 @@ commands:
 
 strategy:
     plugin: memory
+    disk:
+        # Reference for the following options: https://github.com/mirusresearch/catbox-disk
+        # existing dir to store the cache
+        cachePath: /tmp/screwdriver
+        # number of milliseconds between each cache cleanup for disk space recovery, Set to 0 to deactivate entirely.
+        cleanEvery: 0
     memory:
         # Upper limit on the number of bytes that can be stored in the cache
         maxByteSize: 1073741824 # 1GB

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "aws-sdk": "^2.323.0",
     "boom": "^7.2.0",
     "catbox": "^10.0.2",
+    "catbox-disk": "^3.0.0",
     "catbox-memory": "^3.1.2",
     "catbox-s3": "^4.0.0",
     "config": "^1.30.0",


### PR DESCRIPTION
Store artifacts, logs, caches to disk: https://github.com/mirusresearch/catbox-disk.
So that in the chart, we can configure to use this option to avoid external dependencies, e.g.s3, while still keeping the persistency of data. (can make the cache dir a persistent volume in k8s)