### PR TITLE
fix: upload large payload for cache

### DIFF
--- a/plugins/builds.js
+++ b/plugins/builds.js
@@ -105,8 +105,11 @@ exports.plugin = {
                     }
                 });
 
-                // For text/plain payload, upload it as Buffer
-                if (contents.h['content-type'] === 'text/plain') {
+                // For text/plain payload or application/zip, upload it as Buffer
+                // Otherwise, catbox-s3 will try to JSON.stringify (https://github.com/fhemberger/catbox-s3/blob/master/lib/index.js#L236)
+                // and might create issue on large payload
+                if (contents.h['content-type'] === 'text/plain' ||
+                    contents.h['content-type'] === 'application/zip') {
                     value = contents.c;
                 }
 


### PR DESCRIPTION
For text/plain payload or application/zip, upload it as Buffer
Otherwise, catbox-s3 will try to JSON.stringify (https://github.com/fhemberger/catbox-s3/blob/master/lib/index.js#L236) and might create issue on large payload

Related: https://github.com/screwdriver-cd/screwdriver/issues/1257, https://github.com/screwdriver-cd/screwdriver/issues/1281