### PR TITLE
fix: Extend caching scope to jobs and pipelines

### DIFF
--- a/plugins/caches.js
+++ b/plugins/caches.js
@@ -5,7 +5,8 @@ const boom = require('boom');
 const config = require('config');
 const AwsClient = require('../helpers/aws');
 
-const SCHEMA_EVENT_ID = joi.number().integer().positive().label('Event ID');
+const SCHEMA_SCOPE_NAME = joi.string().valid(['events', 'jobs', 'pipelines']).label('Scope Name');
+const SCHEMA_SCOPE_ID = joi.number().integer().positive().label('Event/Job/Pipeline ID');
 const SCHEMA_CACHE_NAME = joi.string().label('Cache Name');
 
 exports.plugin = {
@@ -35,17 +36,46 @@ exports.plugin = {
         server.expose('stats', cache.stats);
         server.route([{
             method: 'GET',
-            path: '/caches/events/{id}/{cacheName}',
+            path: '/caches/{scope}/{id}/{cacheName}',
             handler: async (request, h) => {
-                const { eventId } = request.auth.credentials;
-                const eventIdParam = request.params.id;
+                const cacheName;
+                const cacheKey;
 
-                if (eventIdParam !== eventId) {
-                    return boom.forbidden(`Credential only valid for ${eventId}`);
+                switch (request.params.scope) {
+                    case 'events':
+                        const { eventId } = request.auth.credentials;
+                        const eventIdParam = request.params.id;
+
+                        if (eventIdParam !== eventId) {
+                            return boom.forbidden(`Credential only valid for ${eventId}`);
+                        }
+
+                        cacheName = request.params.cacheName;
+                        cacheKey = `events/${eventIdParam}/${cacheName}`;
+                    case 'jobs':
+                        const { jobId } = request.auth.credentials;
+                        const jobIdParam = request.params.id;
+
+                        if (jobIdParam !== jobId) {
+                            return boom.forbidden(`Credential only valid for ${jobId}`);
+                        }
+
+                        cacheName = request.params.cacheName;
+                        cacheKey = `jobs/${jobIdParam}/${cacheName}`;
+                    case 'pipelines':
+                        const { pipelineId } = request.auth.credentials;
+                        const pipelineIdParam = request.params.id;
+
+                        if (pipelineIdParam !== pipelineId) {
+                            return boom.forbidden(`Credential only valid for ${pipelineId}`);
+                        }
+
+                        cacheName = request.params.cacheName;
+                        cacheKey = `pipelines/${pipelineIdParam}/${cacheName}`;
+                    default:
+                        return boom.forbidden(`Invalid scope`);
                 }
 
-                const cacheName = request.params.cacheName;
-                const cacheKey = `events/${eventIdParam}/${cacheName}`;
                 let value;
 
                 try {
@@ -88,9 +118,9 @@ exports.plugin = {
                 return response;
             },
             options: {
-                description: 'Read event cache',
-                notes: 'Get a specific cached object from an event',
-                tags: ['api', 'events'],
+                description: 'Read event/job/pipeline cache',
+                notes: 'Get a specific cached object from an event, job or pipeline',
+                tags: ['api', 'events', 'jobs', 'pipelines'],
                 auth: {
                     strategies: ['token'],
                     scope: ['build']
@@ -102,24 +132,58 @@ exports.plugin = {
                 },
                 validate: {
                     params: {
-                        id: SCHEMA_EVENT_ID,
+                        scope: SCHEMA_SCOPE_NAME,
+                        id: SCHEMA_SCOPE_ID,
                         cacheName: SCHEMA_CACHE_NAME
                     }
                 }
             }
         }, {
             method: 'PUT',
-            path: '/caches/events/{id}/{cacheName}',
+            path: '/caches/{scope}/{id}/{cacheName}',
             handler: async (request, h) => {
-                const { eventId } = request.auth.credentials;
-                const eventIdParam = request.params.id;
+                const cacheName;
+                const cacheKey;
+                const logId;
 
-                if (eventIdParam !== eventId) {
-                    return boom.forbidden(`Credential only valid for ${eventId}`);
+                switch (request.params.scope) {
+                    case 'events':
+                        const { eventId } = request.auth.credentials;
+                        const eventIdParam = request.params.id;
+
+                        if (eventIdParam !== eventId) {
+                            return boom.forbidden(`Credential only valid for ${eventId}`);
+                        }
+
+                        cacheName = request.params.cacheName;
+                        cacheKey = `events/${eventIdParam}/${cacheName}`;
+                        logId = eventId;
+                    case 'jobs':
+                        const { jobId } = request.auth.credentials;
+                        const jobIdParam = request.params.id;
+
+                        if (jobIdParam !== jobId) {
+                            return boom.forbidden(`Credential only valid for ${jobId}`);
+                        }
+
+                        cacheName = request.params.cacheName;
+                        cacheKey = `jobs/${jobIdParam}/${cacheName}`;
+                        logId = jobId;
+                    case 'pipelines':
+                        const { pipelineId } = request.auth.credentials;
+                        const pipelineIdParam = request.params.id;
+
+                        if (pipelineIdParam !== pipelineId) {
+                            return boom.forbidden(`Credential only valid for ${pipelineId}`);
+                        }
+
+                        cacheName = request.params.cacheName;
+                        cacheKey = `pipelines/${pipelineIdParam}/${cacheName}`;
+                        logId = pipelineId;
+                    default:
+                        return boom.forbidden(`Invalid scope`);
                 }
 
-                const cacheName = request.params.cacheName;
-                const cacheKey = `events/${eventIdParam}/${cacheName}`;
                 const contents = {
                     c: request.payload,
                     h: {}
@@ -141,7 +205,7 @@ exports.plugin = {
                     value = contents.c;
                 }
 
-                request.log(eventId, `Saving ${cacheName} of size ${size} bytes with `
+                request.log(logId, `Saving ${cacheName} of size ${size} bytes with `
                     + `headers ${JSON.stringify(contents.h)}`);
 
                 try {
@@ -155,9 +219,9 @@ exports.plugin = {
                 return h.response().code(202);
             },
             options: {
-                description: 'Write event cache',
-                notes: 'Write a cache object from a specific event',
-                tags: ['api', 'events'],
+                description: 'Write event/job/pipeline cache',
+                notes: 'Write a cache object from a specific event, job or pipeline',
+                tags: ['api', 'events', 'jobs', 'pipelines'],
                 payload: {
                     maxBytes: parseInt(options.maxByteSize, 10),
                     parse: false
@@ -173,24 +237,53 @@ exports.plugin = {
                 },
                 validate: {
                     params: {
-                        id: SCHEMA_EVENT_ID,
+                        scope: SCHEMA_SCOPE_NAME,
+                        id: SCHEMA_SCOPE_ID,
                         cacheName: SCHEMA_CACHE_NAME
                     }
                 }
             }
         }, {
             method: 'DELETE',
-            path: '/caches/events/{id}/{cacheName}',
+            path: '/caches/{scope}/{id}/{cacheName}',
             handler: async (request, h) => {
-                const { eventId } = request.auth.credentials;
-                const eventIdParam = request.params.id;
+                const cacheName;
+                const cacheKey;
 
-                if (eventIdParam !== eventId) {
-                    return boom.forbidden(`Credential only valid for ${eventId}`);
+                switch (request.params.scope) {
+                    case 'events':
+                        const { eventId } = request.auth.credentials;
+                        const eventIdParam = request.params.id;
+
+                        if (eventIdParam !== eventId) {
+                            return boom.forbidden(`Credential only valid for ${eventId}`);
+                        }
+
+                        cacheName = request.params.cacheName;
+                        cacheKey = `events/${eventIdParam}/${cacheName}`;
+                    case 'jobs':
+                        const { jobId } = request.auth.credentials;
+                        const jobIdParam = request.params.id;
+
+                        if (jobIdParam !== jobId) {
+                            return boom.forbidden(`Credential only valid for ${jobId}`);
+                        }
+
+                        cacheName = request.params.cacheName;
+                        cacheKey = `jobs/${jobIdParam}/${cacheName}`;
+                    case 'pipelines':
+                        const { pipelineId } = request.auth.credentials;
+                        const pipelineIdParam = request.params.id;
+
+                        if (pipelineIdParam !== pipelineId) {
+                            return boom.forbidden(`Credential only valid for ${pipelineId}`);
+                        }
+
+                        cacheName = request.params.cacheName;
+                        cacheKey = `pipelines/${pipelineIdParam}/${cacheName}`;
+                    default:
+                        return boom.forbidden(`Invalid scope`);
                 }
-
-                const cacheName = request.params.cacheName;
-                const cacheKey = `events/${eventIdParam}/${cacheName}`;
 
                 try {
                     await cache.drop(cacheKey);
@@ -201,9 +294,9 @@ exports.plugin = {
                 }
             },
             options: {
-                description: 'Delete event cache',
-                notes: 'Delete a specific cached object from an event',
-                tags: ['api', 'events'],
+                description: 'Delete event/job/pipeline cache',
+                notes: 'Delete a specific cached object from an event, job or pipeline',
+                tags: ['api', 'events', 'jobs', 'pipelines'],
                 auth: {
                     strategies: ['token'],
                     scope: ['build']
@@ -215,7 +308,8 @@ exports.plugin = {
                 },
                 validate: {
                     params: {
-                        id: SCHEMA_EVENT_ID,
+                        scope: SCHEMA_SCOPE_NAME,
+                        id: SCHEMA_SCOPE_ID,
                         cacheName: SCHEMA_CACHE_NAME
                     }
                 }

--- a/plugins/caches.js
+++ b/plugins/caches.js
@@ -38,42 +38,48 @@ exports.plugin = {
             method: 'GET',
             path: '/caches/{scope}/{id}/{cacheName}',
             handler: async (request, h) => {
-                const cacheName;
-                const cacheKey;
+                let cacheName;
+                let cacheKey;
 
                 switch (request.params.scope) {
-                    case 'events':
-                        const { eventId } = request.auth.credentials;
-                        const eventIdParam = request.params.id;
+                case 'events': {
+                    const { eventId } = request.auth.credentials;
+                    const eventIdParam = request.params.id;
 
-                        if (eventIdParam !== eventId) {
-                            return boom.forbidden(`Credential only valid for ${eventId}`);
-                        }
+                    if (eventIdParam !== eventId) {
+                        return boom.forbidden(`Credential only valid for ${eventId}`);
+                    }
 
-                        cacheName = request.params.cacheName;
-                        cacheKey = `events/${eventIdParam}/${cacheName}`;
-                    case 'jobs':
-                        const { jobId } = request.auth.credentials;
-                        const jobIdParam = request.params.id;
+                    cacheName = request.params.cacheName;
+                    cacheKey = `events/${eventIdParam}/${cacheName}`;
+                    break;
+                }
+                case 'jobs': {
+                    const { jobId } = request.auth.credentials;
+                    const jobIdParam = request.params.id;
 
-                        if (jobIdParam !== jobId) {
-                            return boom.forbidden(`Credential only valid for ${jobId}`);
-                        }
+                    if (jobIdParam !== jobId) {
+                        return boom.forbidden(`Credential only valid for ${jobId}`);
+                    }
 
-                        cacheName = request.params.cacheName;
-                        cacheKey = `jobs/${jobIdParam}/${cacheName}`;
-                    case 'pipelines':
-                        const { pipelineId } = request.auth.credentials;
-                        const pipelineIdParam = request.params.id;
+                    cacheName = request.params.cacheName;
+                    cacheKey = `jobs/${jobIdParam}/${cacheName}`;
+                    break;
+                }
+                case 'pipelines': {
+                    const { pipelineId } = request.auth.credentials;
+                    const pipelineIdParam = request.params.id;
 
-                        if (pipelineIdParam !== pipelineId) {
-                            return boom.forbidden(`Credential only valid for ${pipelineId}`);
-                        }
+                    if (pipelineIdParam !== pipelineId) {
+                        return boom.forbidden(`Credential only valid for ${pipelineId}`);
+                    }
 
-                        cacheName = request.params.cacheName;
-                        cacheKey = `pipelines/${pipelineIdParam}/${cacheName}`;
-                    default:
-                        return boom.forbidden(`Invalid scope`);
+                    cacheName = request.params.cacheName;
+                    cacheKey = `pipelines/${pipelineIdParam}/${cacheName}`;
+                    break;
+                }
+                default:
+                    return boom.forbidden('Invalid scope');
                 }
 
                 let value;
@@ -142,46 +148,52 @@ exports.plugin = {
             method: 'PUT',
             path: '/caches/{scope}/{id}/{cacheName}',
             handler: async (request, h) => {
-                const cacheName;
-                const cacheKey;
-                const logId;
+                let cacheName;
+                let cacheKey;
+                let logId;
 
                 switch (request.params.scope) {
-                    case 'events':
-                        const { eventId } = request.auth.credentials;
-                        const eventIdParam = request.params.id;
+                case 'events': {
+                    const { eventId } = request.auth.credentials;
+                    const eventIdParam = request.params.id;
 
-                        if (eventIdParam !== eventId) {
-                            return boom.forbidden(`Credential only valid for ${eventId}`);
-                        }
+                    if (eventIdParam !== eventId) {
+                        return boom.forbidden(`Credential only valid for ${eventId}`);
+                    }
 
-                        cacheName = request.params.cacheName;
-                        cacheKey = `events/${eventIdParam}/${cacheName}`;
-                        logId = eventId;
-                    case 'jobs':
-                        const { jobId } = request.auth.credentials;
-                        const jobIdParam = request.params.id;
+                    cacheName = request.params.cacheName;
+                    cacheKey = `events/${eventIdParam}/${cacheName}`;
+                    logId = eventId;
+                    break;
+                }
+                case 'jobs': {
+                    const { jobId } = request.auth.credentials;
+                    const jobIdParam = request.params.id;
 
-                        if (jobIdParam !== jobId) {
-                            return boom.forbidden(`Credential only valid for ${jobId}`);
-                        }
+                    if (jobIdParam !== jobId) {
+                        return boom.forbidden(`Credential only valid for ${jobId}`);
+                    }
 
-                        cacheName = request.params.cacheName;
-                        cacheKey = `jobs/${jobIdParam}/${cacheName}`;
-                        logId = jobId;
-                    case 'pipelines':
-                        const { pipelineId } = request.auth.credentials;
-                        const pipelineIdParam = request.params.id;
+                    cacheName = request.params.cacheName;
+                    cacheKey = `jobs/${jobIdParam}/${cacheName}`;
+                    logId = jobId;
+                    break;
+                }
+                case 'pipelines': {
+                    const { pipelineId } = request.auth.credentials;
+                    const pipelineIdParam = request.params.id;
 
-                        if (pipelineIdParam !== pipelineId) {
-                            return boom.forbidden(`Credential only valid for ${pipelineId}`);
-                        }
+                    if (pipelineIdParam !== pipelineId) {
+                        return boom.forbidden(`Credential only valid for ${pipelineId}`);
+                    }
 
-                        cacheName = request.params.cacheName;
-                        cacheKey = `pipelines/${pipelineIdParam}/${cacheName}`;
-                        logId = pipelineId;
-                    default:
-                        return boom.forbidden(`Invalid scope`);
+                    cacheName = request.params.cacheName;
+                    cacheKey = `pipelines/${pipelineIdParam}/${cacheName}`;
+                    logId = pipelineId;
+                    break;
+                }
+                default:
+                    return boom.forbidden('Invalid scope');
                 }
 
                 const contents = {
@@ -247,42 +259,48 @@ exports.plugin = {
             method: 'DELETE',
             path: '/caches/{scope}/{id}/{cacheName}',
             handler: async (request, h) => {
-                const cacheName;
-                const cacheKey;
+                let cacheName;
+                let cacheKey;
 
                 switch (request.params.scope) {
-                    case 'events':
-                        const { eventId } = request.auth.credentials;
-                        const eventIdParam = request.params.id;
+                case 'events': {
+                    const { eventId } = request.auth.credentials;
+                    const eventIdParam = request.params.id;
 
-                        if (eventIdParam !== eventId) {
-                            return boom.forbidden(`Credential only valid for ${eventId}`);
-                        }
+                    if (eventIdParam !== eventId) {
+                        return boom.forbidden(`Credential only valid for ${eventId}`);
+                    }
 
-                        cacheName = request.params.cacheName;
-                        cacheKey = `events/${eventIdParam}/${cacheName}`;
-                    case 'jobs':
-                        const { jobId } = request.auth.credentials;
-                        const jobIdParam = request.params.id;
+                    cacheName = request.params.cacheName;
+                    cacheKey = `events/${eventIdParam}/${cacheName}`;
+                    break;
+                }
+                case 'jobs': {
+                    const { jobId } = request.auth.credentials;
+                    const jobIdParam = request.params.id;
 
-                        if (jobIdParam !== jobId) {
-                            return boom.forbidden(`Credential only valid for ${jobId}`);
-                        }
+                    if (jobIdParam !== jobId) {
+                        return boom.forbidden(`Credential only valid for ${jobId}`);
+                    }
 
-                        cacheName = request.params.cacheName;
-                        cacheKey = `jobs/${jobIdParam}/${cacheName}`;
-                    case 'pipelines':
-                        const { pipelineId } = request.auth.credentials;
-                        const pipelineIdParam = request.params.id;
+                    cacheName = request.params.cacheName;
+                    cacheKey = `jobs/${jobIdParam}/${cacheName}`;
+                    break;
+                }
+                case 'pipelines': {
+                    const { pipelineId } = request.auth.credentials;
+                    const pipelineIdParam = request.params.id;
 
-                        if (pipelineIdParam !== pipelineId) {
-                            return boom.forbidden(`Credential only valid for ${pipelineId}`);
-                        }
+                    if (pipelineIdParam !== pipelineId) {
+                        return boom.forbidden(`Credential only valid for ${pipelineId}`);
+                    }
 
-                        cacheName = request.params.cacheName;
-                        cacheKey = `pipelines/${pipelineIdParam}/${cacheName}`;
-                    default:
-                        return boom.forbidden(`Invalid scope`);
+                    cacheName = request.params.cacheName;
+                    cacheKey = `pipelines/${pipelineIdParam}/${cacheName}`;
+                    break;
+                }
+                default:
+                    return boom.forbidden('Invalid scope');
                 }
 
                 try {

--- a/test/plugins/caches.test.js
+++ b/test/plugins/caches.test.js
@@ -80,7 +80,7 @@ describe('events plugin test', () => {
     });
 
     describe('Invalid scope', () => {
-        it('returns 403 if scope is not valid', () => (
+        it('returns 400 Bad Request if scope is not valid', () => (
             server.inject({
                 headers: {
                     'x-foo': 'bar'
@@ -91,7 +91,7 @@ describe('events plugin test', () => {
                 },
                 url: `/caches/invalid/${mockEventID}/foo`
             }).then((response) => {
-                assert.equal(response.statusCode, 403);
+                assert.equal(response.statusCode, 400);
             })
         ));
     });

--- a/test/plugins/caches.test.js
+++ b/test/plugins/caches.test.js
@@ -10,6 +10,8 @@ sinon.assert.expose(assert, { prefix: '' });
 
 describe('events plugin test', () => {
     const mockEventID = 1899999;
+    const mockJobId = 10000;
+    const mockPipelineId = 20000;
     let plugin;
     let server;
     let awsClientMock;
@@ -76,6 +78,23 @@ describe('events plugin test', () => {
 
     it('registers the plugin', () => {
         assert.isOk(server.registrations.caches);
+    });
+
+    describe('Invalid scope' () => {
+        it('returns 403 if scope is not valid', () => (
+            server.inject({
+                headers: {
+                    'x-foo': 'bar'
+                },
+                credentials: {
+                    eventId: 5555,
+                    scope: ['build']
+                },
+                url: `/caches/invalid/${mockEventID}/foo`
+            }).then((response) => {
+                assert.equal(response.statusCode, 403);
+            })
+        ));
     });
 
     describe('GET /caches/events/:id/:cacheName', () => {
@@ -150,6 +169,85 @@ describe('events plugin test', () => {
                         scope: ['build']
                     },
                     url: `/caches/events/${mockEventID}/foo`
+                }).then((response) => {
+                    assert.equal(response.statusCode, 500);
+                })
+            ));
+        });
+    });
+
+    describe('GET /caches/jobs/:id/:cacheName', () => {
+        it('returns 404 if not found', () => (
+            server.inject({
+                headers: {
+                    'x-foo': 'bar'
+                },
+                credentials: {
+                    jobId: mockJobID,
+                    scope: ['build']
+                },
+                url: `/caches/jobs/${mockJobID}/foo`
+            }).then((response) => {
+                assert.equal(response.statusCode, 404);
+            })
+        ));
+
+        it('returns 403 if credentials is not valid', () => (
+            server.inject({
+                headers: {
+                    'x-foo': 'bar'
+                },
+                credentials: {
+                    jobId: 5555,
+                    scope: ['build']
+                },
+                url: `/caches/jobs/${mockJobID}/foo`
+            }).then((response) => {
+                assert.equal(response.statusCode, 403);
+            })
+        ));
+
+        describe('caching is not setup right', () => {
+            let badServer;
+
+            beforeEach(() => {
+                badServer = Hapi.server({
+                    cache: {
+                        engine: catmemory,
+                        maxByteSize: 9999999999,
+                        allowMixedContent: true
+                    },
+                    port: 12345
+                });
+
+                badServer.auth.scheme('custom', () => ({
+                    authenticate: (request, h) => h.continue
+                }));
+                badServer.auth.strategy('token', 'custom');
+                badServer.auth.strategy('session', 'custom');
+
+                return badServer.register({
+                    plugin,
+                    options: {
+                        expiresInSec: '100',
+                        maxByteSize: '512'
+                    } });
+            });
+
+            afterEach(() => {
+                badServer = null;
+            });
+
+            it('returns 500 if caching fails', () => (
+                badServer.inject({
+                    headers: {
+                        'x-foo': 'bar'
+                    },
+                    credentials: {
+                        jobId: mockJobID,
+                        scope: ['build']
+                    },
+                    url: `/caches/jobs/${mockJobID}/foo`
                 }).then((response) => {
                     assert.equal(response.statusCode, 500);
                 })
@@ -267,6 +365,116 @@ describe('events plugin test', () => {
         });
     });
 
+    describe('PUT /caches/jobs/:id/:cacheName', () => {
+        let options;
+
+        beforeEach(() => {
+            options = {
+                method: 'PUT',
+                payload: 'THIS IS A TEST',
+                headers: {
+                    'x-foo': 'bar',
+                    'content-type': 'application/zip',
+                    ignore: 'true'
+                },
+                credentials: {
+                    jobId: mockJobID,
+                    scope: ['build']
+                }
+            };
+        });
+
+        it('returns 403 if wrong creds', () => {
+            options.url = '/caches/jobs/122222/foo';
+
+            return server.inject(options).then((response) => {
+                assert.equal(response.statusCode, 403);
+            });
+        });
+
+        it('returns 5xx if cache is bad', () => {
+            options.url = `/caches/jobs/${mockJobID}/foo`;
+            // @note this pushes the payload size over the 512 byte limit
+            options.payload += 'REEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE';
+            options.payload += 'REEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE';
+            options.payload += 'REEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE';
+            options.payload += 'REEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE';
+            options.payload += 'REEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE';
+            options.payload += 'REEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE';
+            options.payload += 'REEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE';
+            options.payload += 'REEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE';
+
+            return server.inject(options).then((response) => {
+                assert.equal(response.statusCode, 503);
+            });
+        });
+
+        it('saves a cache', async () => {
+            options.url = `/caches/jobs/${mockJobID}/foo`;
+
+            options.headers['content-type'] = 'application/x-ndjson';
+            const putResponse = await server.inject(options);
+
+            assert.equal(putResponse.statusCode, 202);
+
+            return server.inject({
+                url: `/caches/jobs/${mockJobID}/foo`,
+                credentials: {
+                    jobId: mockJobID,
+                    scope: ['build']
+                }
+            }).then((getResponse) => {
+                assert.equal(getResponse.statusCode, 200);
+                assert.equal(getResponse.headers['x-foo'], 'bar');
+                assert.equal(getResponse.headers['content-type'], 'application/x-ndjson');
+                assert.isNotOk(getResponse.headers.ignore);
+                assert.equal(getResponse.result, 'THIS IS A TEST');
+            });
+        });
+
+        it('saves a cache without headers for application/zip type', async () => {
+            options.url = `/caches/jobs/${mockJobID}/foo`;
+
+            const putResponse = await server.inject(options);
+
+            assert.equal(putResponse.statusCode, 202);
+
+            return server.inject({
+                url: `/caches/jobs/${mockJobID}/foo`,
+                credentials: {
+                    jobId: mockJobID,
+                    scope: ['build']
+                }
+            }).then((getResponse) => {
+                assert.equal(getResponse.statusCode, 200);
+                assert.equal(getResponse.headers['content-type'], 'application/zip');
+                assert.isNotOk(getResponse.headers['x-foo']);
+                assert.isNotOk(getResponse.headers.ignore);
+                assert.equal(getResponse.result, 'THIS IS A TEST');
+            });
+        });
+
+        it('saves a cache and fetches it with build scoped jwt', async () => {
+            options.url = `/caches/jobs/${mockJobID}/foo`;
+
+            options.headers['content-type'] = 'application/x-ndjson';
+            const putResponse = await server.inject(options);
+
+            assert.equal(putResponse.statusCode, 202);
+
+            return server.inject({
+                url: `/caches/jobs/${mockJobID}/foo`,
+                credentials: {
+                    jobId: mockJobID,
+                    scope: ['build']
+                }
+            }).then((getResponse) => {
+                assert.equal(getResponse.statusCode, 200);
+                assert.equal(getResponse.result, 'THIS IS A TEST');
+            });
+        });
+    });
+
     describe('DELETE /caches/events/:id/:cacheName', () => {
         let getOptions;
         let putOptions;
@@ -329,6 +537,84 @@ describe('events plugin test', () => {
         });
 
         it('deletes an event cache', () => server.inject(putOptions).then((postResponse) => {
+            assert.equal(postResponse.statusCode, 202);
+
+            return server.inject(getOptions).then((getResponse) => {
+                assert.equal(getResponse.statusCode, 200);
+
+                return server.inject(deleteOptions).then((deleteResponse) => {
+                    assert.equal(deleteResponse.statusCode, 200);
+
+                    return server.inject(getOptions).then((getResponse2) => {
+                        assert.equal(getResponse2.statusCode, 404);
+                    });
+                });
+            });
+        }));
+    });
+
+    describe('DELETE /caches/jobs/:id/:cacheName', () => {
+        let getOptions;
+        let putOptions;
+        let deleteOptions;
+
+        beforeEach(() => {
+            getOptions = {
+                headers: {
+                    'x-foo': 'bar'
+                },
+                credentials: {
+                    jobId: mockJobID,
+                    scope: ['build']
+                },
+                url: `/caches/jobs/${mockJobID}/foo`
+            };
+            putOptions = {
+                method: 'PUT',
+                payload: 'THIS IS A TEST',
+                headers: {
+                    'x-foo': 'bar',
+                    'content-type': 'text/plain',
+                    ignore: 'true'
+                },
+                credentials: {
+                    jobId: mockJobID,
+                    scope: ['build']
+                },
+                url: `/caches/jobs/${mockJobID}/foo`
+            };
+            deleteOptions = {
+                method: 'DELETE',
+                headers: {
+                    'x-foo': 'bar',
+                    'content-type': 'text/plain',
+                    ignore: 'true'
+                },
+                credentials: {
+                    jobId: mockJobID,
+                    scope: ['build']
+                },
+                url: `/caches/jobs/${mockJobID}/foo`
+            };
+        });
+
+        it('returns 200 if not found', () => server.inject(getOptions).then((getResponse) => {
+            assert.equal(getResponse.statusCode, 404);
+
+            return server.inject(deleteOptions).then((deleteResponse) => {
+                assert.equal(deleteResponse.statusCode, 200);
+            });
+        }));
+
+        it('returns 403 if credentials is not valid', () => {
+            deleteOptions.credentials.jobId = 5555;
+
+            return server.inject(deleteOptions).then((response) => {
+                assert.equal(response.statusCode, 403);
+            });
+        });
+
+        it('deletes a job cache', () => server.inject(putOptions).then((postResponse) => {
             assert.equal(postResponse.statusCode, 202);
 
             return server.inject(getOptions).then((getResponse) => {

--- a/test/plugins/caches.test.js
+++ b/test/plugins/caches.test.js
@@ -10,8 +10,7 @@ sinon.assert.expose(assert, { prefix: '' });
 
 describe('events plugin test', () => {
     const mockEventID = 1899999;
-    const mockJobId = 10000;
-    const mockPipelineId = 20000;
+    const mockJobID = 10000;
     let plugin;
     let server;
     let awsClientMock;
@@ -80,7 +79,7 @@ describe('events plugin test', () => {
         assert.isOk(server.registrations.caches);
     });
 
-    describe('Invalid scope' () => {
+    describe('Invalid scope', () => {
         it('returns 403 if scope is not valid', () => (
             server.inject({
                 headers: {


### PR DESCRIPTION
Adding support for job and pipeline level caches.

Related: https://github.com/screwdriver-cd/screwdriver/issues/1280
https://github.com/screwdriver-cd/screwdriver/issues/1257