### PR TITLE
fix: Endpoint to invalidate cache

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -65,3 +65,4 @@ strategy:
 
 ecosystem:
     ui: ECOSYSTEM_UI
+    api: ECOSYSTEM_API

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -73,3 +73,4 @@ strategy:
 
 ecosystem:
     ui: https://cd.screwdriver.cd
+    api: https://api.screwdriver.cd

--- a/helpers/aws.js
+++ b/helpers/aws.js
@@ -76,7 +76,7 @@ class AwsClient {
         return this.client.listObjects(params, (e, data) => {
             if (e) return callback(e);
 
-            if (data.isTruncated) return callback();
+            if (data.Contents.length === 0) return callback();
 
             params = { Bucket: this.bucket };
             params.Delete = { Objects: [] };
@@ -85,9 +85,9 @@ class AwsClient {
                 params.Delete.Objects.push({ Key: content.Key });
             });
 
-            return this.client.deleteObjects(params, (err, res) => {
+            return this.client.deleteObjects(params, (err) => {
                 if (err) return callback(err);
-                if (res.isTruncated) return self.invalidateCache(this.bucket, callback);
+                if (data.isTruncated) return self.invalidateCache(cachePath, callback);
 
                 return callback();
             });

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "hoek": "^5.0.3",
     "inert": "^5.1.0",
     "joi": "13.1.2",
+    "request": "^2.88.0",
     "screwdriver-data-schema": "^18.11.5",
     "vision": "^5.3.0",
     "winston": "^2.2.0"

--- a/plugins/caches.js
+++ b/plugins/caches.js
@@ -343,7 +343,7 @@ exports.plugin = {
 
                 let cachePath;
                 const apiUrl = config.get('ecosystem.api');
-                const payload = {
+                const opts = {
                     url: `${apiUrl}/v4/isAdmin`,
                     method: 'GET',
                     headers: {
@@ -355,12 +355,19 @@ exports.plugin = {
 
                 switch (request.params.scope) {
                 case 'events': {
-                    return h.response();
+                    const eventIdParam = request.params.id;
+
+                    opts.qs = {
+                        eventId: eventIdParam
+                    };
+
+                    cachePath = `events/${eventIdParam}/`;
+                    break;
                 }
                 case 'jobs': {
                     const jobIdParam = request.params.id;
 
-                    payload.qs = {
+                    opts.qs = {
                         jobId: jobIdParam
                     };
 
@@ -370,11 +377,11 @@ exports.plugin = {
                 case 'pipelines': {
                     const pipelineIdParam = request.params.id;
 
-                    payload.qs = {
+                    opts.qs = {
                         pipelineId: pipelineIdParam
                     };
 
-                    cachePath = `pipelines/${pipelineIdParam}`;
+                    cachePath = `pipelines/${pipelineIdParam}/`;
                     break;
                 }
                 default:
@@ -382,8 +389,8 @@ exports.plugin = {
                 }
 
                 try {
-                    await req(payload, (err, response) => {
-                        if (!err && response.statusCode === 200) {
+                    await req(opts, (err, response) => {
+                        if (!err && response === true) {
                             return awsClient.invalidateCache(cachePath, (e) => {
                                 if (e) {
                                     console.log('Failed to invalidate cache: ', e);

--- a/test/helpers/aws.test.js
+++ b/test/helpers/aws.test.js
@@ -105,4 +105,26 @@ describe('aws helper test', () => {
             done();
         });
     });
+
+    it('returns err if fails to listObjects', (done) => {
+        const err = new Error('failed to run listObjects');
+
+        clientMock.prototype.listObjects = sinon.stub().yieldsAsync(err);
+
+        return awsClient.invalidateCache(cacheKey, (e) => {
+            assert.deepEqual(e, err);
+            done();
+        });
+    });
+
+    it('returns err if fails to deleteObjects', (done) => {
+        const err = new Error('failed to run deleteObjects');
+
+        clientMock.prototype.listObjects = sinon.stub().yieldsAsync(err);
+
+        return awsClient.invalidateCache(cacheKey, (e) => {
+            assert.deepEqual(e, err);
+            done();
+        });
+    });
 });


### PR DESCRIPTION
Currently there's no mechanism to be able to destroy a cache other than using store-cli on a job. This PR is part of the feature to invalidate cache through a button in the UI (individually for pipeline and job caches).