### PR TITLE
fix: switch k8s api endpoint

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -44,7 +44,7 @@ jobs:
             DOCKER_REPO: screwdrivercd/store
             K8S_CONTAINER: screwdriver-store
             K8S_IMAGE: screwdrivercd/store
-            K8S_HOST: api.k8s.screwdriver.cd
+            K8S_HOST: api.ossd.k8s.screwdriver.cd
             K8S_DEPLOYMENT: sdstore-beta
             SD_STORE: beta.store.screwdriver.cd
         secrets:
@@ -64,7 +64,7 @@ jobs:
             DOCKER_REPO: screwdrivercd/store
             K8S_CONTAINER: screwdriver-store
             K8S_IMAGE: screwdrivercd/store
-            K8S_HOST: api.k8s.screwdriver.cd
+            K8S_HOST: api.ossd.k8s.screwdriver.cd
             K8S_DEPLOYMENT: sdstore
             SD_STORE: store.screwdriver.cd
         secrets:


### PR DESCRIPTION
## Context

Our K8S_DEPLOY step is currently failing.
Previously we point `api.k8s.screwdriver.cd`  to the ips for `api.ossd.k8s.screwdriver.cd` in AWS route53. That means whenever we update the cluster, manual change is needed. Switch to the correct endpoint.

## Objective

This PR updates to the correct host.

## References

Related to https://github.com/screwdriver-cd/guide/pull/256