### PR TITLE
fix: allow pr job to get its parent cache

### DIFF
--- a/plugins/caches.js
+++ b/plugins/caches.js
@@ -56,11 +56,11 @@ exports.plugin = {
                     break;
                 }
                 case 'jobs': {
-                    const { jobId } = request.auth.credentials;
+                    const { jobId, prParentJobId } = request.auth.credentials;
                     const jobIdParam = request.params.id;
 
-                    if (jobIdParam !== jobId) {
-                        return boom.forbidden(`Credential only valid for ${jobId}`);
+                    if (jobIdParam !== jobId && jobIdParam !== prParentJobId) {
+                        return boom.forbidden(`Credential is not valid for ${jobIdParam}`);
                     }
 
                     cacheName = request.params.cacheName;

--- a/test/plugins/caches.test.js
+++ b/test/plugins/caches.test.js
@@ -200,6 +200,41 @@ describe('events plugin test', () => {
             })
         ));
 
+        it('returns 200 if job is asking for parent cache', async () => {
+            const options = {
+                method: 'PUT',
+                payload: 'THIS IS A TEST',
+                headers: {
+                    'x-foo': 'bar',
+                    'content-type': 'text/plain',
+                    ignore: 'true'
+                },
+                credentials: {
+                    jobId: mockJobID,
+                    scope: ['build']
+                }
+            };
+
+            options.url = `/caches/jobs/${mockJobID}/foo`;
+
+            options.headers['content-type'] = 'application/x-ndjson';
+            const putResponse = await server.inject(options);
+
+            assert.equal(putResponse.statusCode, 202);
+
+            return server.inject({
+                url: `/caches/jobs/${mockJobID}/foo`,
+                credentials: {
+                    jobId: 5555,
+                    prParentJobId: mockJobID,
+                    scope: ['build']
+                }
+            }).then((getResponse) => {
+                assert.equal(getResponse.statusCode, 200);
+                assert.equal(getResponse.result, 'THIS IS A TEST');
+            });
+        });
+
         it('returns 403 if credentials is not valid', () => (
             server.inject({
                 headers: {


### PR DESCRIPTION
Allow PR jobs to get its parent job. For example: `PR-1:main` can get cache from `main`

Blocked by: https://github.com/screwdriver-cd/screwdriver/pull/1409
Related: https://github.com/screwdriver-cd/screwdriver/issues/1382