### PR TITLE
fix: enable to use s3 compatible

### DIFF
--- a/helpers/aws.js
+++ b/helpers/aws.js
@@ -7,19 +7,26 @@ class AwsClient {
      * Construct a Client
      * @method constructor
      * @param  {Object}    config
-     * @param  {String}    config.accessKeyId        AWS access key ID.
-     * @param  {String}    config.secretAccessKey    AWS secret access key.
+     * @param  {String}    config.endpoint           S3 compatible endpoint
+     * @param  {String}    config.accessKeyId        S3 access key ID.
+     * @param  {String}    config.secretAccessKey    S3 secret access key.
      * @param  {String}    config.region             the region to send service requests to
      * @param  {String}    config.forcePathStyle     whether to force path style URLs for S3 objects
-     * @param  {String}    config.bucket             s3 bucket
+     * @param  {String}    config.bucket             S3 bucket
      */
     constructor(config) {
-        this.client = new AWS.S3({
+        const options = {
             accessKeyId: config.accessKeyId,
             secretAccessKey: config.secretAccessKey,
             region: config.region,
             s3ForcePathStyle: config.forcePathStyle
-        });
+        };
+
+        if (config.endpoint) {
+            options.endpoint = config.endpoint;
+        }
+
+        this.client = new AWS.S3(options);
         this.bucket = config.bucket;
     }
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "chai-as-promised": "^6.0.0",
     "eslint": "^4.3.0",
     "eslint-config-screwdriver": "^3.0.0",
-    "jenkins-mocha": "^4.0.0",
+    "jenkins-mocha": "^6.0.0",
     "js-yaml": "^3.6.1",
     "jsonwebtoken": "^8.4.0",
     "mockery": "^2.0.0",
@@ -75,6 +75,6 @@
     "request": "^2.88.0",
     "screwdriver-data-schema": "^18.34.2",
     "vision": "^5.4.3",
-    "winston": "^2.2.0"
+    "winston": "^3.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
-    "test": "jenkins-mocha --recursive --timeout 3000",
+    "test": "jenkins-mocha --recursive --timeout 3000 --exit",
     "start": "./bin/server",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
@@ -45,15 +45,15 @@
     }
   },
   "devDependencies": {
-    "chai": "^3.5.0",
-    "chai-as-promised": "^6.0.0",
+    "chai": "^4.0.0",
+    "chai-as-promised": "^7.1.1",
     "eslint": "^4.3.0",
     "eslint-config-screwdriver": "^3.0.0",
     "jenkins-mocha": "^6.0.0",
     "js-yaml": "^3.6.1",
     "jsonwebtoken": "^8.4.0",
     "mockery": "^2.0.0",
-    "sinon": "^4.5.0"
+    "sinon": "^7.0.0"
   },
   "dependencies": {
     "aws-sdk": "^2.361.0",

--- a/plugins/caches.js
+++ b/plugins/caches.js
@@ -309,7 +309,7 @@ exports.plugin = {
                     await cache.drop(cacheKey);
                     request.log([cacheKey, 'info'], 'Successfully deleted a cache');
 
-                    return h.response();
+                    return h.response().code(204);
                 } catch (err) {
                     request.log([cacheKey, 'error'], `Failed to delete a cache: ${err}`);
 
@@ -411,7 +411,7 @@ exports.plugin = {
                 })).then(() => {
                     request.log([cachePath, 'info'], 'Successfully deleted a cache');
 
-                    return h.response().code(200);
+                    return h.response().code(204);
                 }).catch((err) => {
                     if (err === 'Permission denied') {
                         return boom.forbidden(err);

--- a/plugins/commands.js
+++ b/plugins/commands.js
@@ -140,10 +140,13 @@ exports.plugin = {
 
                 try {
                     await cache.drop(id);
+                    request.log([id, 'info'], 'Successfully deleted a command');
 
-                    return h.response();
+                    return h.response().code(200);
                 } catch (err) {
-                    throw err;
+                    request.log([id, 'error'], `Failed to delete a command: ${err}`);
+
+                    throw boom.serverUnavailable(err.message, err);
                 }
             },
             options: {

--- a/plugins/commands.js
+++ b/plugins/commands.js
@@ -142,7 +142,7 @@ exports.plugin = {
                     await cache.drop(id);
                     request.log([id, 'info'], 'Successfully deleted a command');
 
-                    return h.response().code(200);
+                    return h.response().code(204);
                 } catch (err) {
                     request.log([id, 'error'], `Failed to delete a command: ${err}`);
 

--- a/test/plugins/caches.test.js
+++ b/test/plugins/caches.test.js
@@ -567,7 +567,7 @@ describe('events plugin test', () => {
             assert.equal(getResponse.statusCode, 404);
 
             return server.inject(deleteOptions).then((deleteResponse) => {
-                assert.equal(deleteResponse.statusCode, 200);
+                assert.equal(deleteResponse.statusCode, 204);
             });
         }));
 
@@ -586,7 +586,7 @@ describe('events plugin test', () => {
                 assert.equal(getResponse.statusCode, 200);
 
                 return server.inject(deleteOptions).then((deleteResponse) => {
-                    assert.equal(deleteResponse.statusCode, 200);
+                    assert.equal(deleteResponse.statusCode, 204);
 
                     return server.inject(getOptions).then((getResponse2) => {
                         assert.equal(getResponse2.statusCode, 404);
@@ -645,7 +645,7 @@ describe('events plugin test', () => {
             assert.equal(getResponse.statusCode, 404);
 
             return server.inject(deleteOptions).then((deleteResponse) => {
-                assert.equal(deleteResponse.statusCode, 200);
+                assert.equal(deleteResponse.statusCode, 204);
             });
         }));
 
@@ -664,7 +664,7 @@ describe('events plugin test', () => {
                 assert.equal(getResponse.statusCode, 200);
 
                 return server.inject(deleteOptions).then((deleteResponse) => {
-                    assert.equal(deleteResponse.statusCode, 200);
+                    assert.equal(deleteResponse.statusCode, 204);
 
                     return server.inject(getOptions).then((getResponse2) => {
                         assert.equal(getResponse2.statusCode, 404);
@@ -700,7 +700,7 @@ describe('events plugin test', () => {
             });
 
             return server.inject(deleteOptions).then((deleteResponse) => {
-                assert.equal(deleteResponse.statusCode, 200);
+                assert.equal(deleteResponse.statusCode, 204);
             });
         });
 

--- a/test/plugins/commands.test.js
+++ b/test/plugins/commands.test.js
@@ -232,7 +232,7 @@ describe('commands plugin test', () => {
             assert.equal(getResponse.statusCode, 404);
 
             return server.inject(deleteOptions).then((deleteResponse) => {
-                assert.equal(deleteResponse.statusCode, 200);
+                assert.equal(deleteResponse.statusCode, 204);
             });
         }));
 
@@ -243,7 +243,7 @@ describe('commands plugin test', () => {
                 assert.equal(getResponse.statusCode, 200);
 
                 return server.inject(deleteOptions).then((deleteResponse) => {
-                    assert.equal(deleteResponse.statusCode, 200);
+                    assert.equal(deleteResponse.statusCode, 204);
 
                     return server.inject(getOptions).then((getResponse2) => {
                         assert.equal(getResponse2.statusCode, 404);


### PR DESCRIPTION
The helper client only points to AWS.
This PR enables to use cache invalidation in S3 compatible.
And add more logs for debugging.