### PR TITLE
fix: artifact is to be downloaded

### DIFF
--- a/plugins/builds.js
+++ b/plugins/builds.js
@@ -5,6 +5,8 @@ const boom = require('boom');
 
 const SCHEMA_BUILD_ID = joi.number().integer().positive().label('Build ID');
 const SCHEMA_ARTIFACT_ID = joi.string().label('Artifact ID');
+const DOWNLOAD = joi.string().valid(['', 'false', 'true']).label('Flag to trigger download');
+const TOKEN = joi.string().label('Auth Token');
 const DEFAULT_TTL = 24 * 60 * 60 * 1000; // 1 day
 const DEFAULT_BYTES = 1024 * 1024 * 1024; // 1GB
 
@@ -57,6 +59,12 @@ exports.plugin = {
                     response.headers['content-type'] = 'text/plain';
                 }
 
+                // only if the artifact is requested as downloadable item
+                if (request.query.download === 'true') {
+                    // let browser sniff for the correct filename w/ extension
+                    response.headers['content-disposition'] = 'attachment';
+                }
+
                 return response;
             },
             options: {
@@ -76,6 +84,10 @@ exports.plugin = {
                     params: {
                         id: SCHEMA_BUILD_ID,
                         artifact: SCHEMA_ARTIFACT_ID
+                    },
+                    query: {
+                        download: DOWNLOAD,
+                        token: TOKEN
                     }
                 }
             }

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -169,19 +169,30 @@ describe('builds plugin test', () => {
 
             assert.equal(putResponse.statusCode, 202);
 
-            return server.inject({
+            const getResponse = await server.inject({
                 url: `/builds/${mockBuildID}/foo`,
                 credentials: {
                     username: mockBuildID,
                     scope: ['user']
                 }
-            }).then((getResponse) => {
-                assert.equal(getResponse.statusCode, 200);
-                assert.equal(getResponse.headers['x-foo'], 'bar');
-                assert.equal(getResponse.headers['content-type'], 'application/x-ndjson');
-                assert.isNotOk(getResponse.headers.ignore);
-                assert.equal(getResponse.result, 'THIS IS A TEST');
             });
+
+            assert.equal(getResponse.statusCode, 200);
+            assert.equal(getResponse.headers['x-foo'], 'bar');
+            assert.equal(getResponse.headers['content-type'], 'application/x-ndjson');
+            assert.isNotOk(getResponse.headers.ignore);
+            assert.equal(getResponse.result, 'THIS IS A TEST');
+
+            const downloadResponse = await server.inject({
+                url: `/builds/${mockBuildID}/foo?download=true`,
+                credentials: {
+                    username: mockBuildID,
+                    scope: ['user']
+                }
+            });
+
+            assert.equal(downloadResponse.statusCode, 200);
+            assert.equal(downloadResponse.headers['content-disposition'], 'attachment');
         });
 
         it('saves an artifact without headers for text/plain type', async () => {


### PR DESCRIPTION
make artifact downloaded by the browser

Browser can sniff the mime type from the file signature, and that's why your browser decides to display file on web page sometimes while, instead, download it, the other times.


related to: https://github.com/screwdriver-cd/screwdriver/issues/1476

related PRs:
- https://github.com/screwdriver-cd/screwdriver/pull/1498
- https://github.com/screwdriver-cd/ui/pull/408