### PR TITLE
fix: stream caches download and upload for s3

### DIFF
--- a/helpers/aws.js
+++ b/helpers/aws.js
@@ -1,6 +1,9 @@
 'use strict';
 
 const AWS = require('aws-sdk');
+const stream = require('stream');
+const Boom = require('boom');
+const winston = require('winston');
 
 class AwsClient {
     /**
@@ -28,6 +31,7 @@ class AwsClient {
 
         this.client = new AWS.S3(options);
         this.bucket = config.bucket;
+        this.segment = config.segment;
     }
 
     /**
@@ -98,6 +102,89 @@ class AwsClient {
 
                 return callback();
             });
+        });
+    }
+
+    /**
+     * Parse cache key
+     * @method getStoragePathForKey
+     * @param {String}              cacheKey          Path of the cache
+     * @return {String}
+     */
+    getStoragePathForKey(cacheKey) {
+        const convert = str => str
+            // Remove leading/trailing slashes
+            .replace(/(^\/|\/$)/g, '')
+            // Replace special URL characters
+            .replace(/[?&#%]/g, '~');
+
+        const parsedKey = convert(cacheKey);
+
+        return `${this.segment}/${parsedKey}`;
+    }
+
+    /**
+     * upload data as stream
+     * @method uploadAsStream
+     * @param {Object}              config               Config object
+     * @param {Stream}              config.payload       Payload to upload
+     * @param {String}              config.cacheKey      Path to cache
+     * @return {Promise}
+     */
+    uploadAsStream({ payload, cacheKey }) {
+        // stream the data to s3
+        const passthrough = new stream.PassThrough();
+        const params = {
+            Bucket: this.bucket,
+            Key: this.getStoragePathForKey(cacheKey),
+            Expires: new Date(new Date().getTime()),
+            ContentType: 'application/octet-stream',
+            Body: passthrough
+        };
+
+        payload.pipe(passthrough);
+
+        return this.client.upload(params).promise();
+    }
+
+    /**
+     * Get download stream
+     * @method downloadStream
+     * *@param {Object}             config                Config object
+     * @param {String}              config.cacheKey       Path to cache
+     * @param {Promise}                                   Resolve with a stream if request succeeds, reject with boom object
+     */
+    getDownloadStream({ cacheKey }) {
+        // get a download stream from s3
+        const params = {
+            Bucket: this.bucket,
+            Key: this.getStoragePathForKey(cacheKey)
+        };
+
+        return new Promise((resolve, reject) => {
+            const req = this.client.getObject(params);
+            let s3stream;
+
+            // check the header before returning a stream, if request failed, reject
+            req.on('httpHeaders', (statusCode) => {
+                if (statusCode >= 400) {
+                    winston.error(`Fetch ${cacheKey} request failed: ${statusCode}`);
+
+                    return reject(new Boom('Fetch cache request failed', { statusCode }));
+                }
+
+                return resolve(s3stream);
+            });
+
+            s3stream = req.createReadStream()
+                .on('error', (error) => {
+                    winston.error(`Error streaming ${cacheKey}: ${error}`);
+                })
+                .on('data', (chunk) => {
+                    winston.info(`Received ${chunk.length} bytes of data for ${cacheKey}`);
+                });
+
+            return s3stream;
         });
     }
 }

--- a/helpers/aws.js
+++ b/helpers/aws.js
@@ -16,6 +16,7 @@ class AwsClient {
      * @param  {String}    config.region             the region to send service requests to
      * @param  {String}    config.forcePathStyle     whether to force path style URLs for S3 objects
      * @param  {String}    config.bucket             S3 bucket
+     * @param  {String}    config.segment            S3 segment
      */
     constructor(config) {
         const options = {
@@ -137,7 +138,7 @@ class AwsClient {
         const params = {
             Bucket: this.bucket,
             Key: this.getStoragePathForKey(cacheKey),
-            Expires: new Date(new Date().getTime()),
+            Expires: new Date(),
             ContentType: 'application/octet-stream',
             Body: passthrough
         };
@@ -149,8 +150,8 @@ class AwsClient {
 
     /**
      * Get download stream
-     * @method downloadStream
-     * *@param {Object}             config                Config object
+     * @method getDownloadStream
+     * @param {Object}             config                Config object
      * @param {String}              config.cacheKey       Path to cache
      * @param {Promise}                                   Resolve with a stream if request succeeds, reject with boom object
      */

--- a/plugins/caches.js
+++ b/plugins/caches.js
@@ -10,6 +10,22 @@ const SCHEMA_SCOPE_NAME = joi.string().valid(['events', 'jobs', 'pipelines']).la
 const SCHEMA_SCOPE_ID = joi.number().integer().positive().label('Event/Job/Pipeline ID');
 const SCHEMA_CACHE_NAME = joi.string().label('Cache Name');
 
+/**
+ * Convert stream to buffer
+ * @method streamToBuffer
+ * @param  {Stream}       stream
+ * @return {Buffer}
+ */
+function streamToBuffer(stream) {
+    return new Promise((resolve, reject) => {
+        const buffers = [];
+
+        stream.on('error', reject);
+        stream.on('data', data => buffers.push(data));
+        stream.on('end', () => resolve(Buffer.concat(buffers)));
+    });
+}
+
 exports.plugin = {
     name: 'caches',
 
@@ -22,15 +38,17 @@ exports.plugin = {
      * @param  {Integer}  options.maxByteSize   Maximum Bytes to accept
      */
     register(server, options) {
+        const segment = 'caches';
         const cache = server.cache({
-            segment: 'caches',
+            segment,
             expiresIn: parseInt(options.expiresInSec, 10)
         });
-
         const strategyConfig = config.get('strategy');
+        const usingS3 = strategyConfig.plugin === 's3';
         let awsClient;
 
-        if (strategyConfig.plugin === 's3') {
+        if (usingS3) {
+            strategyConfig.s3.segment = segment;
             awsClient = new AwsClient(strategyConfig.s3);
         }
 
@@ -84,28 +102,40 @@ exports.plugin = {
                 }
 
                 let value;
-
-                try {
-                    value = await cache.get(cacheKey);
-                } catch (err) {
-                    throw err;
-                }
-
-                if (!value) {
-                    throw boom.notFound();
-                }
-
                 let response;
 
-                if (value.c) {
-                    response = h.response(Buffer.from(value.c.data));
-                    response.headers = value.h;
+                // for old json files, the value is hidden in an object, we cannot stream it directly
+                if (usingS3 && cacheName.endsWith('zip')) {
+                    try {
+                        value = await awsClient.getDownloadStream({ cacheKey });
+                        response = h.response(value);
+                        response.headers['content-type'] = 'application/octet-stream';
+                    } catch (err) {
+                        request.log([cacheName, 'error'], `Failed to stream the cache: ${err}`);
+                        throw err;
+                    }
                 } else {
-                    response = h.response(Buffer.from(value));
-                    response.headers['content-type'] = 'text/plain';
+                    try {
+                        value = await cache.get(cacheKey);
+                    } catch (err) {
+                        request.log([cacheName, 'error'], `Failed to get the cache: ${err}`);
+                        throw err;
+                    }
+
+                    if (!value) {
+                        throw boom.notFound();
+                    }
+
+                    if (value.c) {
+                        response = h.response(Buffer.from(value.c.data));
+                        response.headers = value.h;
+                    } else {
+                        response = h.response(Buffer.from(value));
+                        response.headers['content-type'] = 'text/plain';
+                    }
                 }
 
-                if (strategyConfig.plugin !== 's3') {
+                if (!usingS3) {
                     return response;
                 }
 
@@ -198,12 +228,11 @@ exports.plugin = {
                     return boom.forbidden('Invalid scope');
                 }
 
+                const payload = request.payload;
                 const contents = {
-                    c: request.payload,
+                    c: {},
                     h: {}
                 };
-                const size = Buffer.byteLength(request.payload);
-                let value = contents;
 
                 // Store all x-* and content-type headers
                 Object.keys(request.headers).forEach((header) => {
@@ -212,22 +241,41 @@ exports.plugin = {
                     }
                 });
 
-                // For text/plain, upload it as Buffer
-                // Otherwise, catbox-s3 will try to JSON.stringify (https://github.com/fhemberger/catbox-s3/blob/master/lib/index.js#L236)
-                // and might create issue on large payload
-                if (contents.h['content-type'] === 'text/plain') {
-                    value = contents.c;
-                }
-
-                request.log(logId, `Saving ${cacheName} of size ${size} bytes with `
+                request.log(logId, `Saving ${cacheName} with `
                     + `headers ${JSON.stringify(contents.h)}`);
 
-                try {
-                    await cache.set(cacheKey, value, 0);
-                } catch (err) {
-                    request.log([cacheName, 'error'], `Failed to store in cache: ${err}`);
+                // stream large payload if using s3
+                if (usingS3 && contents.h['content-type'] === 'text/plain') {
+                    try {
+                        await awsClient.uploadAsStream({
+                            payload,
+                            cacheKey
+                        });
+                    } catch (err) {
+                        request.log([cacheName, 'error'], `Failed to stream the cache: ${err}`);
 
-                    throw boom.serverUnavailable(err.message, err);
+                        throw boom.serverUnavailable(err.message, err);
+                    }
+                } else {
+                    try {
+                        let value = contents;
+
+                        // convert stream to buffer, otherwise catbox cannot parse
+                        contents.c = await streamToBuffer(payload);
+
+                        // For text/plain, upload it as Buffer
+                        // Otherwise, catbox-s3 will try to JSON.stringify (https://github.com/fhemberger/catbox-s3/blob/master/lib/index.js#L236)
+                        // and might create issue on large payload
+                        if (contents.h['content-type'] === 'text/plain') {
+                            value = contents.c;
+                        }
+
+                        await cache.set(cacheKey, value, 0);
+                    } catch (err) {
+                        request.log([cacheName, 'error'], `Failed to store in cache: ${err}`);
+
+                        throw boom.serverUnavailable(err.message, err);
+                    }
                 }
 
                 return h.response().code(202);
@@ -238,7 +286,8 @@ exports.plugin = {
                 tags: ['api', 'events', 'jobs', 'pipelines'],
                 payload: {
                     maxBytes: parseInt(options.maxByteSize, 10),
-                    parse: false
+                    parse: false,
+                    output: 'stream'
                 },
                 auth: {
                     strategies: ['token'],

--- a/plugins/caches.js
+++ b/plugins/caches.js
@@ -390,7 +390,7 @@ exports.plugin = {
             method: 'DELETE',
             path: '/caches/{scope}/{id}',
             handler: (request, h) => {
-                if (strategyConfig.plugin !== 's3') {
+                if (!usingS3) {
                     return h.response();
                 }
 

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -4,7 +4,7 @@ shared:
 jobs:
     main:
         environment:
-            SD_SONAR_OPTS: "-Dsonar.sources=lib, plugins -Dsonar.javascript.lcov.reportPath=coverage/lcov.info"
+            SD_SONAR_OPTS: "-Dsonar.sources=lib,plugins,helpers -Dsonar.javascript.lcov.reportPath=artifacts/coverage/lcov.info"
         requires: [~pr, ~commit]
         steps:
             - install: npm install

--- a/test/plugins/caches.test.js
+++ b/test/plugins/caches.test.js
@@ -5,15 +5,15 @@ const sinon = require('sinon');
 const Hapi = require('hapi');
 const mockery = require('mockery');
 const catmemory = require('catbox-memory');
+const Boom = require('boom');
 
 sinon.assert.expose(assert, { prefix: '' });
 
-describe('events plugin test', () => {
+describe('caches plugin test using memory', () => {
     const mockEventID = 1899999;
     const mockJobID = 10000;
     let plugin;
     let server;
-    let awsClientMock;
     let reqMock;
     let configMock;
 
@@ -27,14 +27,10 @@ describe('events plugin test', () => {
     beforeEach(() => {
         configMock = {
             get: sinon.stub().returns({
-                plugin: 's3'
+                plugin: 'memory',
+                s3: {}
             })
         };
-
-        awsClientMock = sinon.stub().returns({
-            updateLastModified: sinon.stub().yields(null),
-            invalidateCache: sinon.stub().yields(null)
-        });
 
         reqMock = sinon.stub();
 
@@ -42,7 +38,6 @@ describe('events plugin test', () => {
             statusCode: 403
         });
 
-        mockery.registerMock('../helpers/aws', awsClientMock);
         mockery.registerMock('config', configMock);
         mockery.registerMock('request', reqMock);
 
@@ -325,23 +320,6 @@ describe('events plugin test', () => {
             });
         });
 
-        it('returns 5xx if cache is bad', () => {
-            options.url = `/caches/events/${mockEventID}/foo`;
-            // @note this pushes the payload size over the 512 byte limit
-            options.payload += 'REEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE';
-            options.payload += 'REEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE';
-            options.payload += 'REEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE';
-            options.payload += 'REEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE';
-            options.payload += 'REEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE';
-            options.payload += 'REEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE';
-            options.payload += 'REEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE';
-            options.payload += 'REEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE';
-
-            return server.inject(options).then((response) => {
-                assert.equal(response.statusCode, 503);
-            });
-        });
-
         it('saves a cache', async () => {
             options.url = `/caches/events/${mockEventID}/foo`;
 
@@ -432,23 +410,6 @@ describe('events plugin test', () => {
 
             return server.inject(options).then((response) => {
                 assert.equal(response.statusCode, 403);
-            });
-        });
-
-        it('returns 5xx if cache is bad', () => {
-            options.url = `/caches/jobs/${mockJobID}/foo`;
-            // @note this pushes the payload size over the 512 byte limit
-            options.payload += 'REEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE';
-            options.payload += 'REEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE';
-            options.payload += 'REEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE';
-            options.payload += 'REEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE';
-            options.payload += 'REEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE';
-            options.payload += 'REEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE';
-            options.payload += 'REEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE';
-            options.payload += 'REEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE';
-
-            return server.inject(options).then((response) => {
-                assert.equal(response.statusCode, 503);
             });
         });
 
@@ -672,6 +633,219 @@ describe('events plugin test', () => {
                 });
             });
         }));
+    });
+
+    describe('DELETE /caches/:scope/:id', () => {
+        let deleteOptions;
+
+        beforeEach(() => {
+            deleteOptions = {
+                method: 'DELETE',
+                headers: {
+                    'x-foo': 'bar',
+                    'content-type': 'text/plain',
+                    ignore: 'true'
+                },
+                credentials: {
+                    username: 'testuser',
+                    scope: ['user']
+                },
+                url: `/caches/jobs/${mockJobID}`
+            };
+        });
+
+        it('Returns 200 if successfully invalidate cache', () => {
+            reqMock.yieldsAsync(null, {
+                statusCode: 200,
+                body: true
+            });
+
+            return server.inject(deleteOptions).then((deleteResponse) => {
+                assert.equal(deleteResponse.statusCode, 200);
+            });
+        });
+    });
+});
+
+describe('caches plugin test using s3', () => {
+    const mockEventID = 1899999;
+    const mockJobID = 10000;
+    let plugin;
+    let server;
+    let awsClientMock;
+    let reqMock;
+    let configMock;
+    let getDownloadStreamMock;
+    let uploadAsStreamMock;
+
+    before(() => {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+    });
+
+    beforeEach(() => {
+        configMock = {
+            get: sinon.stub().returns({
+                plugin: 's3',
+                s3: {}
+            })
+        };
+
+        getDownloadStreamMock = sinon.stub().resolves(null);
+        uploadAsStreamMock = sinon.stub().resolves(null);
+
+        awsClientMock = sinon.stub().returns({
+            updateLastModified: sinon.stub().yields(null),
+            invalidateCache: sinon.stub().yields(null),
+            getDownloadStream: getDownloadStreamMock,
+            uploadAsStream: uploadAsStreamMock
+        });
+
+        reqMock = sinon.stub();
+
+        reqMock.yieldsAsync({
+            statusCode: 403
+        });
+
+        mockery.registerMock('../helpers/aws', awsClientMock);
+        mockery.registerMock('config', configMock);
+        mockery.registerMock('request', reqMock);
+
+        // eslint-disable-next-line global-require
+        plugin = require('../../plugins/caches');
+
+        server = Hapi.server({
+            cache: {
+                engine: catmemory,
+                maxByteSize: 512,
+                allowMixedContent: true
+            },
+            port: 1234
+        });
+
+        server.auth.scheme('custom', () => ({
+            authenticate: (request, h) => h.authenticated()
+        }));
+        server.auth.strategy('token', 'custom');
+        server.auth.strategy('session', 'custom');
+
+        return server.register({
+            plugin,
+            options: {
+                expiresInSec: '100',
+                maxByteSize: '5368709120'
+            } })
+            .then(() => server.start());
+    });
+
+    afterEach(async () => {
+        await server.stop();
+        server = null;
+        mockery.deregisterAll();
+        mockery.resetCache();
+    });
+
+    after(() => {
+        mockery.disable();
+    });
+
+    it('registers the plugin', () => {
+        assert.isOk(server.registrations.caches);
+    });
+
+    describe('GET /caches/events/:id/:cacheName', () => {
+        it('returns 200 if not found', () => (
+            server.inject({
+                headers: {
+                    'x-foo': 'bar'
+                },
+                credentials: {
+                    eventId: mockEventID,
+                    scope: ['build']
+                },
+                url: `/caches/events/${mockEventID}/foo.zip`
+            }).then((response) => {
+                assert.calledWith(getDownloadStreamMock, {
+                    cacheKey: `events/${mockEventID}/foo.zip`
+                });
+                assert.equal(response.statusCode, 200);
+            })
+        ));
+
+        it('returns 404 if not found', () => {
+            getDownloadStreamMock.rejects(new Boom('Not found', {
+                statusCode: 404
+            }));
+
+            return server.inject({
+                headers: {
+                    'x-foo': 'bar'
+                },
+                credentials: {
+                    eventId: mockEventID,
+                    scope: ['build']
+                },
+                url: `/caches/events/${mockEventID}/foo.zip`
+            }).then((response) => {
+                assert.calledWith(getDownloadStreamMock, {
+                    cacheKey: `events/${mockEventID}/foo.zip`
+                });
+                assert.equal(response.statusCode, 404);
+            });
+        });
+    });
+
+    describe('PUT /caches/events/:id/:cacheName', () => {
+        let options;
+
+        beforeEach(() => {
+            options = {
+                method: 'PUT',
+                payload: 'THIS IS A TEST',
+                headers: {
+                    'x-foo': 'bar',
+                    'content-type': 'text/plain',
+                    ignore: 'true'
+                },
+                credentials: {
+                    eventId: mockEventID,
+                    scope: ['build']
+                }
+            };
+        });
+
+        it('streams a cache without headers for text/plain type', async () => {
+            options.url = `/caches/events/${mockEventID}/foo.zip`;
+
+            const putResponse = await server.inject(options);
+
+            assert.equal(putResponse.statusCode, 202);
+
+            return server.inject({
+                url: `/caches/events/${mockEventID}/foo.zip`,
+                credentials: {
+                    eventId: mockEventID,
+                    scope: ['build']
+                }
+            }).then((getResponse) => {
+                assert.equal(getResponse.statusCode, 200);
+                assert.equal(getResponse.headers['content-type'], 'application/octet-stream');
+                assert.isNotOk(getResponse.headers['x-foo']);
+                assert.isNotOk(getResponse.headers.ignore);
+            });
+        });
+
+        it('returns 503 if streaming failed', async () => {
+            uploadAsStreamMock.rejects(new Error('failed'));
+
+            options.url = `/caches/events/${mockEventID}/foo.zip`;
+
+            const putResponse = await server.inject(options);
+
+            assert.equal(putResponse.statusCode, 503);
+        });
     });
 
     describe('DELETE /caches/:scope/:id', () => {


### PR DESCRIPTION
- Currently, hapi stores payload in raw Buffer,  which is taking a lot of memory when uploading big files. Store pods are getting killed by OOM.

- This PR will stream download and upload for all the `zip` files for `caches` endpoint if using `s3`. Other cases will not be changed. It will still do upload / download as the old way.

- `maxBytes` won't work as what it was before since the data is a stream. But we still need it since the default value is `1m`. If the part of stream reading in is larger than that, hapi will throw 413.

Related to: https://github.com/screwdriver-cd/screwdriver/issues/1561