### PR TITLE
fix: remove the logging for chunk data length

### DIFF
--- a/helpers/aws.js
+++ b/helpers/aws.js
@@ -180,9 +180,6 @@ class AwsClient {
             s3stream = req.createReadStream()
                 .on('error', (error) => {
                     winston.error(`Error streaming ${cacheKey}: ${error}`);
-                })
-                .on('data', (chunk) => {
-                    winston.info(`Received ${chunk.length} bytes of data for ${cacheKey}`);
                 });
 
             return s3stream;


### PR DESCRIPTION
This is dumping a lot noise to the logs and increase unnecessary memory usage