### PR TITLE
feat: Enable to change partSize option

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -62,6 +62,8 @@ strategy:
         signatureVersion: S3_SIG_VER
         # Whether to force path style URLs for S3 objects.
         forcePathStyle: S3_FORCE_PATH_STYLE
+        # aws-sdk options for the size in bytes for each individual part to be uploaded.
+        partSize: S3_PART_SIZE
 
 ecosystem:
     ui: ECOSYSTEM_UI

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -70,6 +70,8 @@ strategy:
         bucket: YOUR-BUCKET-ID
         # Whether to force path style URLs for S3 objects.
         forcePathStyle: false
+        # aws-sdk options for the size in bytes for each individual part to be uploaded.
+        partSize: 5242880 # default 5mb
 
 ecosystem:
     ui: https://cd.screwdriver.cd

--- a/helpers/aws.js
+++ b/helpers/aws.js
@@ -17,6 +17,7 @@ class AwsClient {
      * @param  {String}    config.forcePathStyle     whether to force path style URLs for S3 objects
      * @param  {String}    config.bucket             S3 bucket
      * @param  {String}    config.segment            S3 segment
+     * @param  {Integer}   config.partSize           aws-sdk upload option
      */
     constructor(config) {
         const options = {
@@ -33,6 +34,7 @@ class AwsClient {
         this.client = new AWS.S3(options);
         this.bucket = config.bucket;
         this.segment = config.segment;
+        this.partSize = config.partSize;
     }
 
     /**
@@ -142,10 +144,13 @@ class AwsClient {
             ContentType: 'application/octet-stream',
             Body: passthrough
         };
+        const options = {
+            partSize: this.partSize
+        };
 
         payload.pipe(passthrough);
 
-        return this.client.upload(params).promise();
+        return this.client.upload(params, options).promise();
     }
 
     /**

--- a/test/helpers/aws.test.js
+++ b/test/helpers/aws.test.js
@@ -18,6 +18,7 @@ describe('aws helper test', () => {
     const cacheKey = 'test';
     const testBucket = 'TEST_REGION';
     const localCache = 'THIS IS A TEST';
+    const partSize = 10 * 1024 * 1024;
     const testMD5 = crypto.createHash('md5').update(localCache).digest('hex');
     const TestStream = class extends stream.Readable {
         _read() {}
@@ -68,7 +69,8 @@ describe('aws helper test', () => {
             region,
             s3ForcePathStyle,
             bucket: testBucket,
-            segment: 'caches'
+            segment: 'caches',
+            partSize
         });
     });
 
@@ -150,10 +152,15 @@ describe('aws helper test', () => {
             Bucket: testBucket,
             Key: `caches/${cacheKey}`
         };
+        const uploadOption = {
+            partSize
+        };
 
         return awsClient.uploadAsStream({ cacheKey, payload: new TestStream() })
             .then(() => {
-                assert.calledWith(clientMock.prototype.upload, sinon.match(uploadParam));
+                assert.calledWith(clientMock.prototype.upload,
+                    sinon.match(uploadParam),
+                    sinon.match(uploadOption));
             });
     });
 


### PR DESCRIPTION
# Context
We want to customize aws-sdk's partSize option for upload method.
https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#upload-property

# Objective
Add partSize option to config, and pass partSize option to upload method.