### PR TITLE
feat: Always using stream upload when using s3 storage

### DIFF
--- a/plugins/builds.js
+++ b/plugins/builds.js
@@ -142,7 +142,7 @@ exports.plugin = {
                 });
 
                 // stream large payload if using s3
-                if (usingS3 && id.endsWith('.zip')) {
+                if (usingS3) {
                     try {
                         await awsClient.uploadAsStream({
                             payload,


### PR DESCRIPTION
**Description of changes:**
When we cannot use `SD_ZIP_ARTIFACTS` options because of not using AWS Lambda, other type than `.zip` file can also become large size.

Even if that case, we want to use stream upload because that file can also become large size.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of your choice and that I have the authority necessary to make this contribution on behalf of its copyright owner.
