### PR TITLE
have proper content-type for html files

### DIFF
--- a/plugins/builds.js
+++ b/plugins/builds.js
@@ -81,6 +81,10 @@ exports.plugin = {
                         response = h.response(Buffer.from(value));
                         response.headers['content-type'] = 'text/plain';
                     }
+
+                    if (id.endsWith('.html')) {
+                        response.headers['content-type'] = 'text/html';
+                    }
                 }
 
                 // only if the artifact is requested as downloadable item

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -221,6 +221,28 @@ describe('builds plugin test', () => {
             });
         });
 
+        it('saves an html artifact without headers for text/html type', async () => {
+            options.url = `/builds/${mockBuildID}/foo.html`;
+
+            const putResponse = await server.inject(options);
+
+            assert.equal(putResponse.statusCode, 202);
+
+            return server.inject({
+                url: `/builds/${mockBuildID}/foo.html`,
+                credentials: {
+                    username: mockBuildID,
+                    scope: ['user']
+                }
+            }).then((getResponse) => {
+                assert.equal(getResponse.statusCode, 200);
+                assert.equal(getResponse.headers['content-type'], 'text/html; charset=utf-8');
+                assert.isNotOk(getResponse.headers['x-foo']);
+                assert.isNotOk(getResponse.headers.ignore);
+                assert.equal(getResponse.result, 'THIS IS A TEST');
+            });
+        });
+
         it('saves an artifact and fetches it with pipeline scoped jwt', async () => {
             options.url = `/builds/${mockBuildID}/foo`;
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
html artifacts (like diff-cover output) is displayed in browser as plain text. This change will set the proper content-type for html artifacts so they are displayable.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of your choice and that I have the authority necessary to make this contribution on behalf of its copyright owner.
