### PR TITLE
[Feature] Allow to config cors to be an array of strings instead of one string

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ $ export STRATEGY=memory
 $ export PORT=8080
 ```
 
+All the possible environment variables are [defined here](config/custom-environment-variables.yaml).
+
+## Storage Strategies
+
+Right now we're using [catbox](https://github.com/hapijs/catbox) for storage, so we can support any of their plugins (Redis, S3, Memcached, etc.).  We only installed the [memory](https://github.com/hapijs/catbox-memory) and [S3](https://github.com/fhemberger/catbox-s3) ones for now.
+
 Or if you want to use [`disk`](https://github.com/mirusresearch/catbox-disk) strategy as to persist cache, you can config as following, please be sure to create `./store-data` as a local directory though
 
 ```
@@ -66,12 +72,6 @@ strategy:
         cleanEvery: 3600000
         partition : 'cache'
 ```
-
-All the possible environment variables are [defined here](config/custom-environment-variables.yaml).
-
-## Storage Strategies
-
-Right now we're using [catbox](https://github.com/hapijs/catbox) for storage, so we can support any of their plugins (Redis, S3, Memcached, etc.).  We only installed the [memory](https://github.com/hapijs/catbox-memory) and [S3](https://github.com/fhemberger/catbox-s3) ones for now.
 
 ## Testing
 

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -68,3 +68,8 @@ strategy:
 ecosystem:
     ui: ECOSYSTEM_UI
     api: ECOSYSTEM_API
+    # Array of extra origins allowed to do CORS to API
+    allowCors:
+        __name: ECOSYSTEM_ALLOW_CORS
+        __format: json
+

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -76,3 +76,4 @@ strategy:
 ecosystem:
     ui: https://cd.screwdriver.cd
     api: https://api.screwdriver.cd
+    allowCors: []

--- a/lib/server.js
+++ b/lib/server.js
@@ -34,9 +34,15 @@ const CUSTOM_PLUGINS = [
  * @return {http.Server}                            A listener: NodeJS http.Server object
  */
 module.exports = async (config) => {
+    let corsOrigins = [config.ecosystem.ui];
+
+    if (Array.isArray(config.ecosystem.allowCors)) {
+        corsOrigins = corsOrigins.concat(config.ecosystem.allowCors);
+    }
+
     // Allow ui to query store
     const cors = {
-        origin: [config.ecosystem.ui]
+        origin: corsOrigins
     };
 
     // Create a server with a host and port

--- a/test/lib/server.test.js
+++ b/test/lib/server.test.js
@@ -8,7 +8,8 @@ describe('server case', function () {
     this.timeout(5000);
 
     const ecosystem = {
-        ui: 'http://example.com'
+        ui: 'http://example.com',
+        allowCors: []
     };
 
     let hapiEngine;


### PR DESCRIPTION
## Context
Config multiple cors endpoint in store is not possible. One can only set cors to be one endpoint.

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Before, in `config/` you can only specify 

```
ecosystem:
    allowCors: 'http://localhost:4200'
```

After this PR, you could make `allowCors` to be an array

```
ecosystem:
    allowCors: ['http://localhost:4200', 'http://localhost:4201']
```


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
