### PR TITLE
fix(readme): update README with catbox-disk strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ $ export STRATEGY=memory
 $ export PORT=8080
 ```
 
+Or if you want to use [`disk`](https://github.com/mirusresearch/catbox-disk) strategy as to persist cache, you can config as following, please be sure to create `./store-data` as a local directory though
+
+```
+strategy:
+    plugin: disk
+    disk:
+        cachePath: './store-data'
+        cleanEvery: 3600000
+        partition : 'cache'
+```
+
 All the possible environment variables are [defined here](config/custom-environment-variables.yaml).
 
 ## Storage Strategies

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "license": "BSD-3-Clause",
   "author": "St. John Johnson <st.john.johnson@gmail.com>",
   "contributors": [
+    "Alan Dong <alandong2016@gmail.com>",
     "Dao Lam <daolam112@gmail.com>",
     "Darren Matsumoto <aeneascorrupt@gmail.com>",
     "Jeremiah Wuenschel <jeremiah.wuenschel@gmail.com>",


### PR DESCRIPTION
## Context

The instruction in the current README only has strategy for in memory, this PR adds instruction to use `catbox-disk` strategy to persist data in disk.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
Add instruction to how to use `disk` strategy to REAMDE
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
