### PR TITLE
fix: Failed to download artifacts that have Japanese filename

### DIFF
--- a/plugins/builds.js
+++ b/plugins/builds.js
@@ -91,7 +91,7 @@ exports.plugin = {
                 if (request.query.download === 'true') {
                     // let browser sniff for the correct filename w/ extension
                     response.headers['content-disposition'] =
-                        `attachment; filename="${artifact.split('/').pop()}"`;
+                        `attachment; filename="${encodeURI(artifact.split('/').pop())}"`;
                 }
 
                 return response;

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -195,7 +195,45 @@ describe('builds plugin test', () => {
 
             assert.equal(downloadResponse.statusCode, 200);
             assert.equal(
-                downloadResponse.headers['content-disposition'], 'attachment; filename="foo"'
+                downloadResponse.headers['content-disposition'],
+                'attachment; filename="foo"'
+            );
+        });
+
+        it('saves an artifact of Japanese filename', async () => {
+            options.url = `/builds/${mockBuildID}/日本語.txt`;
+
+            options.headers['content-type'] = 'application/x-ndjson';
+            const putResponse = await server.inject(options);
+
+            assert.equal(putResponse.statusCode, 202);
+
+            const getResponse = await server.inject({
+                url: `/builds/${mockBuildID}/日本語.txt`,
+                credentials: {
+                    username: mockBuildID,
+                    scope: ['user']
+                }
+            });
+
+            assert.equal(getResponse.statusCode, 200);
+            assert.equal(getResponse.headers['x-foo'], 'bar');
+            assert.equal(getResponse.headers['content-type'], 'application/x-ndjson');
+            assert.isNotOk(getResponse.headers.ignore);
+            assert.equal(getResponse.result, 'THIS IS A TEST');
+
+            const downloadResponse = await server.inject({
+                url: `/builds/${mockBuildID}/日本語.txt?download=true`,
+                credentials: {
+                    username: mockBuildID,
+                    scope: ['user']
+                }
+            });
+
+            assert.equal(downloadResponse.statusCode, 200);
+            assert.equal(
+                downloadResponse.headers['content-disposition'],
+                'attachment; filename="%E6%97%A5%E6%9C%AC%E8%AA%9E.txt"'
             );
         });
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Content-Disposition header can not accept Japanese as the filename.
```
190725/035746.918, (1564027066918:prod-sdstore-7995d6889c-skz6z:878:jyi5b9tc:10015) [error] message: The header content contains invalid characters, stack: TypeError: The header content c
ontains invalid characters
    at validateHeader (_http_outgoing.js:494:11)
    at ServerResponse.setHeader (_http_outgoing.js:498:3)
    at Object.internals.writeHead (/usr/src/app/node_modules/hapi/lib/transmit.js:323:21)
    at Object.internals.transmit (/usr/src/app/node_modules/hapi/lib/transmit.js:105:15)
    at Object.exports.send (/usr/src/app/node_modules/hapi/lib/transmit.js:32:25)
    at <anonymous>
    at process._tickDomainCallback (internal/process/next_tick.js:229:7)
```
Adding encoding to the filename, the artifact is able to be download.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This is to use artifacts of Japanese filename.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
