### PR TITLE
feat: add absolute path check and skip API prefix if its absolute path

### DIFF
--- a/helpers/iframe.js
+++ b/helpers/iframe.js
@@ -7,7 +7,7 @@ const apiVersion = 'v4';
 
 const iframeScript = `
     function isAbsolutePath(href) {
-        const absolutePath = new RegExp('^(http|https)://');
+        const absolutePath = new RegExp('^((http|https)://|#)');
         return absolutePath.test(href);
     };
 

--- a/helpers/iframe.js
+++ b/helpers/iframe.js
@@ -6,6 +6,11 @@ const apiUrl = config.get('ecosystem.api');
 const apiVersion = 'v4';
 
 const iframeScript = `
+    function isAbsolutePath(href) {
+        const absolutePath = new RegExp('^(http|https)://');
+        return absolutePath.test(href);
+    };
+
     function replaceHref(apiHref='${apiUrl}') {
         const currentIframeHref = new URL(document.location.href);
         const urlOrigin = currentIframeHref.origin;
@@ -21,6 +26,9 @@ const iframeScript = `
         const anchors = document.getElementsByTagName('a');
         for (let anchor of anchors) {
           let originalHref = anchor.attributes.href.value;
+          if (isAbsolutePath(originalHref)) {
+              continue;
+          }
           const newUrl = apiUrlOrigin + '/' + apiVersion + '/' + urlFileDir + '/' + originalHref;
           anchor.href = newUrl.replace('ARTIFACTS', 'artifacts') + '?type=preview';
           anchor.addEventListener('click', function(e) {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
For artifacts preview, the href link in the html are prefixed with API bluntly. This PR will only mask href links that are `relative path`, i.e.  `/plugins/x/y.html`


If these links are

1) absolute path like `https://istanbul.js.org/`, 
2) relative path acting like anchor tag, i.e  `#L3` or `#summary`

We will skip masking.


## Objective

Skip api prefix masking for `absolute path` or `#anchor`

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
![image](https://user-images.githubusercontent.com/15989893/62319957-f3f95600-b453-11e9-952e-e62f23795543.png)

https://www.coffeecup.com/help/articles/absolute-vs-relative-pathslinks/

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
