### PR TITLE
feat: artifacts made iframe script to mask css and js relative links

### DIFF
--- a/helpers/mime.js
+++ b/helpers/mime.js
@@ -1,5 +1,6 @@
 'use strict';
 
+
 /**
  * getMimeFromFileExtension
  * @param  {String} fileExtension  File extension (e.g. css, txt, html)
@@ -24,7 +25,11 @@ function getMimeFromFileExtension(fileExtension) {
 
     return mime;
 }
+const executableMimes =['text/css', 'text/javascript'];
+const displableMimes = ['text/html'];
 
 module.exports = {
-    getMimeFromFileExtension
+    getMimeFromFileExtension,
+    displableMimes,
+    executableMimes
 };

--- a/helpers/mime.js
+++ b/helpers/mime.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 /**
  * getMimeFromFileExtension
  * @param  {String} fileExtension  File extension (e.g. css, txt, html)
@@ -25,7 +24,7 @@ function getMimeFromFileExtension(fileExtension) {
 
     return mime;
 }
-const executableMimes =['text/css', 'text/javascript'];
+const executableMimes = ['text/css', 'text/javascript'];
 const displableMimes = ['text/html'];
 
 module.exports = {

--- a/plugins/builds.js
+++ b/plugins/builds.js
@@ -103,7 +103,7 @@ exports.plugin = {
                     response.headers['content-disposition'] =
                         `attachment; filename="${encodeURI(fileName)}"`;
                 } else if (request.query.type === 'preview') {
-                    if  (displableMimes.includes(mime)){
+                    if (displableMimes.includes(mime)) {
                         const $ = cheerio.load(Buffer.from(value));
                         const scriptNode = `<script>${iframeScript}</script>`;
 

--- a/plugins/builds.js
+++ b/plugins/builds.js
@@ -8,7 +8,7 @@ const cheerio = require('cheerio');
 const AwsClient = require('../helpers/aws');
 const { iframeScript } = require('../helpers/iframe');
 const { streamToBuffer } = require('../helpers/helper');
-const { getMimeFromFileExtension } = require('../helpers/mime');
+const { getMimeFromFileExtension, displableMimes, executableMimes } = require('../helpers/mime');
 
 const SCHEMA_BUILD_ID = joi.number().integer().positive().label('Build ID');
 const SCHEMA_ARTIFACT_ID = joi.string().label('Artifact ID');
@@ -102,14 +102,18 @@ exports.plugin = {
                     // let browser sniff for the correct filename w/ extension
                     response.headers['content-disposition'] =
                         `attachment; filename="${encodeURI(fileName)}"`;
-                } else if (request.query.type === 'preview' && mime === 'text/html') {
-                    const $ = cheerio.load(Buffer.from(value));
-                    const scriptNode = `<script>${iframeScript}</script>`;
+                } else if (request.query.type === 'preview') {
+                    if  (displableMimes.includes(mime)){
+                        const $ = cheerio.load(Buffer.from(value));
+                        const scriptNode = `<script>${iframeScript}</script>`;
 
-                    // inject postMessage into code
-                    $('body').append(scriptNode);
-                    response = h.response($.html());
-                    response.headers['content-type'] = mime;
+                        // inject postMessage into code
+                        $('body').append(scriptNode);
+                        response = h.response($.html());
+                        response.headers['content-type'] = mime;
+                    } else if (executableMimes.includes(mime)) {
+                        response.headers['content-type'] = mime;
+                    }
                 }
 
                 return response;


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

People want to see their css and js files loaded in the artifacts preview, we heard you and we are making it happening. ❤️ ❤️ 

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This PR adds artifacts preview with css and js loaded inside the iframe.

## References
Before:
![image](https://user-images.githubusercontent.com/15989893/62400719-157e3e80-b535-11e9-9440-631b49826695.png)


After:
![image](https://user-images.githubusercontent.com/15989893/62400691-f41d5280-b534-11e9-8af2-8e9bb1e76acc.png)


<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
