### PR TITLE
feat: replace relative image links to be prefixed with api endpoint

### DIFF
--- a/helpers/iframe.js
+++ b/helpers/iframe.js
@@ -64,6 +64,17 @@ const iframeScript = `
                 addScript(maskWithAPI(apiUrlOrigin, apiVersion, urlFileDir, originalHref));
             }
         }
+
+        const imageLinks = document.getElementsByTagName('img');
+        for (let imageLink of imageLinks) {
+            if (imageLink.attributes.src) {
+                let originalHref = imageLink.attributes.src.value;
+                if (isAbsolutePath(imageLink)) {
+                    continue;
+                }
+                imageLink.src = maskWithAPI(apiUrlOrigin, apiVersion, urlFileDir, originalHref);
+            }
+        }
     }
 
     function addCss(src) {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Image urls that are relative path would be rendered as expected. We need to prefix api endpoint to images that have relative paths.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Add api prefix to image links

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
