### PR TITLE
fix: artifacts images not displayed correctly in Firefox

### DIFF
--- a/helpers/mime.js
+++ b/helpers/mime.js
@@ -7,16 +7,15 @@
  */
 function getMimeFromFileExtension(fileExtension) {
     let mime = '';
-
     switch (fileExtension.toLowerCase()) {
+    case 'html':
+        mime = 'text/html';
+        break;
     case 'css':
         mime = 'text/css';
         break;
     case 'js':
         mime = 'text/javascript';
-        break;
-    case 'html':
-        mime = 'text/html';
         break;
     case 'png':
         mime = 'image/png';
@@ -33,11 +32,11 @@ function getMimeFromFileExtension(fileExtension) {
 
     return mime;
 }
-const executableMimes = ['text/css', 'text/javascript'];
+const knownMimes = ['text/css', 'text/javascript', 'image/png', 'image/jpeg'];
 const displableMimes = ['text/html'];
 
 module.exports = {
     getMimeFromFileExtension,
     displableMimes,
-    executableMimes
+    knownMimes
 };

--- a/helpers/mime.js
+++ b/helpers/mime.js
@@ -7,6 +7,7 @@
  */
 function getMimeFromFileExtension(fileExtension) {
     let mime = '';
+
     switch (fileExtension.toLowerCase()) {
     case 'html':
         mime = 'text/html';

--- a/helpers/mime.js
+++ b/helpers/mime.js
@@ -18,6 +18,15 @@ function getMimeFromFileExtension(fileExtension) {
     case 'html':
         mime = 'text/html';
         break;
+    case 'png':
+        mime = 'image/png';
+        break;
+    case 'jpeg':
+        mime = 'image/jpeg';
+        break;
+    case 'jpg':
+        mime = 'image/jpeg';
+        break;
     default:
         break;
     }

--- a/plugins/builds.js
+++ b/plugins/builds.js
@@ -8,7 +8,7 @@ const cheerio = require('cheerio');
 const AwsClient = require('../helpers/aws');
 const { iframeScript } = require('../helpers/iframe');
 const { streamToBuffer } = require('../helpers/helper');
-const { getMimeFromFileExtension, displableMimes, executableMimes } = require('../helpers/mime');
+const { getMimeFromFileExtension, displableMimes, knownMimes } = require('../helpers/mime');
 
 const SCHEMA_BUILD_ID = joi.number().integer().positive().label('Build ID');
 const SCHEMA_ARTIFACT_ID = joi.string().label('Artifact ID');
@@ -111,7 +111,7 @@ exports.plugin = {
                         $('body').append(scriptNode);
                         response = h.response($.html());
                         response.headers['content-type'] = mime;
-                    } else if (executableMimes.includes(mime)) {
+                    } else if (knownMimes.includes(mime)) {
                         response.headers['content-type'] = mime;
                     }
                 }


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Firefox:

![image](https://user-images.githubusercontent.com/15989893/70267124-a61e9280-1752-11ea-8393-9aa856554a87.png)
Firefox is not displaying images from artifacts.

Chrome:

![image](https://user-images.githubusercontent.com/15989893/70267650-b6833d00-1753-11ea-85cc-63a3c8dfdd5e.png)

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

The root case is that `IE` and `Chrome` are doing some MIME sniffing by default, while Firefox doesn’t. Ironically, Firefox is the one upholds the principle in the W3C guide, again.

This PR adds `png`, `jpg` and `jpeg` extensions to images to set MIME type explicitly.  


Live Demo: https://cd.screwdriver.cd/pipelines/3687/events

Corresponding Screwdriver Repo: https://github.com/screwdriver-cd-test/artifacts-test

## References

- [Properly Configuring Server MIME Types - Web security](https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Configuring_server_MIME_types)

- [How Mozilla determines MIME Types - Mozilla](https://developer.mozilla.org/en-US/docs/Mozilla/How_Mozilla_determines_MIME_Types)

- [Media Types by IANA](https://www.iana.org/assignments/media-types/media-types.xhtml)
## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
