### PR TITLE
fix: incorporated mime-types library

### DIFF
--- a/helpers/mime.js
+++ b/helpers/mime.js
@@ -1,38 +1,16 @@
 'use strict';
 
+const mime = require('mime-types');
+
 /**
  * getMimeFromFileExtension
  * @param  {String} fileExtension  File extension (e.g. css, txt, html)
  * @return {String} text/html
  */
 function getMimeFromFileExtension(fileExtension) {
-    let mime = '';
-
-    switch (fileExtension.toLowerCase()) {
-    case 'html':
-        mime = 'text/html';
-        break;
-    case 'css':
-        mime = 'text/css';
-        break;
-    case 'js':
-        mime = 'text/javascript';
-        break;
-    case 'png':
-        mime = 'image/png';
-        break;
-    case 'jpeg':
-        mime = 'image/jpeg';
-        break;
-    case 'jpg':
-        mime = 'image/jpeg';
-        break;
-    default:
-        break;
-    }
-
-    return mime;
+    return mime.lookup(fileExtension) || '';
 }
+
 const knownMimes = ['text/css', 'text/javascript', 'image/png', 'image/jpeg'];
 const displableMimes = ['text/html'];
 

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "hoek": "^5.0.3",
     "inert": "^5.1.2",
     "joi": "13.1.2",
+    "mime-types": "^2.1.25",
     "request": "^2.88.0",
     "screwdriver-data-schema": "^18.34.2",
     "screwdriver-logger": "^1.0.0",


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Instead of maintaining the MIME types in the `helpers/mime.js`, we can take advantage and offload the MIME lookup to [mime-types](https://www.npmjs.com/package/mime-types) instead.


## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This PR removes the homebrew mime helpers, and utilize [mime-types (https://github.com/jshttp/mime-types) as suggested in [pullrequestreview-327807721](https://github.com/screwdriver-cd/store/pull/95#pullrequestreview-327807721)

Thank you @DekusDenial for point out. I used [file-type](https://www.npmjs.com/package/file-type) and does way too much than we need here. `mime-types` seems to fit the needs, so refactoring code accordingly. 

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
