### PR TITLE
fix: private s3 bucket, config to take ACL param

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ npm-debug.log
 config/local.*
 .nyc_output
 package-lock.json
+
+.idea/

--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -64,6 +64,8 @@ strategy:
         forcePathStyle: S3_FORCE_PATH_STYLE
         # aws-sdk options for the size in bytes for each individual part to be uploaded.
         partSize: S3_PART_SIZE
+        # the default ACL for putting objects in your s3 bucket
+        ACL: S3_DEFAULT_ACL
 
 ecosystem:
     ui: ECOSYSTEM_UI

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -72,6 +72,8 @@ strategy:
         forcePathStyle: false
         # aws-sdk options for the size in bytes for each individual part to be uploaded.
         partSize: 5242880 # default 5mb
+        # the default ACL for putting objects in your s3 bucket
+        ACL: 'public-read'
 
 ecosystem:
     ui: https://cd.screwdriver.cd


### PR DESCRIPTION

## Context

Currently the screwdriver store uses catbox-s3 which by default will attempt to establish the s3 cache using public-read ACL. This is a no go for private repos, and private clusters as far as my company is concerned. 

## Objective

Allow the ACL setting to be passed through to catbox-s3, such that a screwdriver cluster manager can override the ACL from public-read to private. 

## References

https://github.com/screwdriver-cd/screwdriver/issues/1934

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.