### PR TITLE
fix(1957): move to node:12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8
+FROM node:12
 
 # Screwdriver Store Version
 ARG VERSION=latest

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
-    "test": "jenkins-mocha --recursive --timeout 3000 --exit",
+    "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --recursive --timeout 4000 --retries 1 --exit --allow-uncaught true --color true",
     "start": "./bin/server",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
@@ -50,10 +50,11 @@
     "chai-as-promised": "^7.1.1",
     "eslint": "^4.3.0",
     "eslint-config-screwdriver": "^3.0.0",
-    "jenkins-mocha": "^6.0.0",
     "js-yaml": "^3.6.1",
     "jsonwebtoken": "^8.4.0",
+    "mocha": "^7.0.1",
     "mockery": "^2.0.0",
+    "nyc": "^15.0.0",
     "sinon": "^7.0.0"
   },
   "dependencies": {

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-    image: node:8
+    image: node:12
 
 jobs:
     main:

--- a/test/lib/server.test.js
+++ b/test/lib/server.test.js
@@ -13,6 +13,7 @@ describe('server case', function () {
     };
 
     let hapiEngine;
+    let server;
 
     beforeEach(() => {
         // eslint-disable-next-line global-require
@@ -20,13 +21,15 @@ describe('server case', function () {
     });
 
     afterEach(() => {
-        hapiEngine = null;
+        if (server) {
+            return server.stop();
+        }
+
+        return null;
     });
 
     describe('positive cases', () => {
         it('does it with a different port', async () => {
-            let server;
-
             try {
                 server = await hapiEngine({
                     httpd: {


### PR DESCRIPTION
## Context

Screwdriver API is running on node:8 container which is no longer supported.

## Objective

Upgrade to latest LTS of node. 

## References

https://github.com/screwdriver-cd/screwdriver/issues/1722

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.
