### PR TITLE
feat(2087): Defer check for admin to API and add auth scope sdapi

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "pretest": "eslint .",
     "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --recursive --timeout 4000 --retries 1 --exit --allow-uncaught true --color true",
     "start": "./bin/server",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post",
+    "debug": "node --nolazy --inspect-brk=9229 ./bin/server"
   },
   "repository": {
     "type": "git",

--- a/plugins/caches.js
+++ b/plugins/caches.js
@@ -406,7 +406,7 @@ exports.plugin = {
                 tags: ['api', 'events', 'jobs', 'pipelines'],
                 auth: {
                     strategies: ['token'],
-                    scope: ['user']
+                    scope: ['sdapi']
                 },
                 plugins: {
                     'hapi-swagger': {

--- a/plugins/caches.js
+++ b/plugins/caches.js
@@ -5,7 +5,6 @@ const boom = require('boom');
 const config = require('config');
 const AwsClient = require('../helpers/aws');
 const { streamToBuffer } = require('../helpers/helper');
-const req = require('request');
 
 const SCHEMA_SCOPE_NAME = joi.string().valid(['events', 'jobs', 'pipelines']).label('Scope Name');
 const SCHEMA_SCOPE_ID = joi.number().integer().positive().label('Event/Job/Pipeline ID');
@@ -374,86 +373,32 @@ exports.plugin = {
         }, {
             method: 'DELETE',
             path: '/caches/{scope}/{id}',
-            handler: (request, h) => {
-                if (!usingS3) {
-                    return h.response();
-                }
-
+            handler: async (request, h) => {
                 let cachePath;
-                const apiUrl = config.get('ecosystem.api');
-                const opts = {
-                    url: `${apiUrl}/v4/isAdmin`,
-                    method: 'GET',
-                    headers: {
-                        Authorization: `Bearer ${request.auth.token}`,
-                        'Content-Type': 'application/json'
-                    },
-                    json: true
-                };
 
-                switch (request.params.scope) {
-                case 'events': {
-                    const eventIdParam = request.params.id;
-
-                    opts.qs = {
-                        eventId: eventIdParam
-                    };
-
-                    cachePath = `events/${eventIdParam}/`;
-                    break;
-                }
-                case 'jobs': {
-                    const jobIdParam = request.params.id;
-
-                    opts.qs = {
-                        jobId: jobIdParam
-                    };
-
-                    cachePath = `jobs/${jobIdParam}/`;
-                    break;
-                }
-                case 'pipelines': {
-                    const pipelineIdParam = request.params.id;
-
-                    opts.qs = {
-                        pipelineId: pipelineIdParam
-                    };
-
-                    cachePath = `pipelines/${pipelineIdParam}/`;
-                    break;
-                }
-                default:
-                    return boom.forbidden('Invalid scope');
-                }
-
-                return new Promise((resolve, reject) => req(opts, (err, response) => {
-                    if (!err && response.body === true) {
-                        return awsClient.invalidateCache(cachePath, (e) => {
-                            if (e) {
-                                return reject(e);
-                            }
-
-                            return resolve();
-                        });
+                try {
+                    if (!usingS3) {
+                        return h.response();
                     }
 
-                    if (!err && response.body === false) {
-                        return reject('Permission denied');
-                    }
+                    const { scope, id } = request.params;
 
-                    return reject(err);
-                })).then(() => {
+                    cachePath = `${scope}/${id}/`;
+
+                    await awsClient.invalidateCache(cachePath, (err) => {
+                        if (err) {
+                            throw err;
+                        }
+                    });
+
                     request.log([cachePath, 'info'], 'Successfully deleted a cache');
 
                     return h.response().code(204);
-                }).catch((err) => {
-                    if (err === 'Permission denied') {
-                        return boom.forbidden(err);
-                    }
+                } catch (err) {
                     request.log([cachePath, 'error'], `Failed to delete a cache: ${err}`);
 
                     return h.response().code(500);
-                });
+                }
             },
             options: {
                 description: 'Invalidate cache folder',

--- a/test/plugins/caches.test.js
+++ b/test/plugins/caches.test.js
@@ -651,7 +651,7 @@ describe('caches plugin test using memory', () => {
                 },
                 credentials: {
                     username: 'testuser',
-                    scope: ['user']
+                    scope: ['sdapi']
                 },
                 url: `/caches/jobs/${mockJobID}`
             };
@@ -665,6 +665,22 @@ describe('caches plugin test using memory', () => {
 
             return server.inject(deleteOptions).then((deleteResponse) => {
                 assert.equal(deleteResponse.statusCode, 200);
+            });
+        });
+
+        it('Returns 403 if auth scope is different', () => {
+            reqMock.yieldsAsync(null, {
+                statusCode: 200,
+                body: true
+            });
+
+            deleteOptions.credentials = {
+                username: 'testuser',
+                scope: ['user']
+            };
+
+            return server.inject(deleteOptions).then((deleteResponse) => {
+                assert.equal(deleteResponse.statusCode, 403);
             });
         });
     });
@@ -859,7 +875,7 @@ describe('caches plugin test using s3', () => {
                 },
                 credentials: {
                     username: 'testuser',
-                    scope: ['user']
+                    scope: ['sdapi']
                 },
                 url: `/caches/jobs/${mockJobID}`
             };
@@ -888,6 +904,17 @@ describe('caches plugin test using s3', () => {
 
             return server.inject(deleteOptions).then((deleteResponse) => {
                 assert.equal(deleteResponse.statusCode, 500);
+            });
+        });
+
+        it('Returns 403 if auth scope is different', () => {
+            deleteOptions.credentials = {
+                username: 'testuser',
+                scope: ['user']
+            };
+
+            return server.inject(deleteOptions).then((deleteResponse) => {
+                assert.equal(deleteResponse.statusCode, 403);
             });
         });
     });


### PR DESCRIPTION
## Context

Clear Cache api in store reaches out to SD API to check for admin permissions of user. As this can be achieved in SD API, this api call is no longer required.

## Objective

This PR removes the check for user admin permissions and relies on SD api to verify it.

## References

https://github.com/screwdriver-cd/screwdriver/issues/2087

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
