### PR TITLE
fix: control max http timeut

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -66,6 +66,8 @@ strategy:
         partSize: S3_PART_SIZE
         # the default ACL for putting objects in your s3 bucket
         ACL: S3_DEFAULT_ACL
+        # default http timeout
+        httpTimeout: S3_HTTP_TIMEOUT
 
 ecosystem:
     ui: ECOSYSTEM_UI

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -74,6 +74,8 @@ strategy:
         partSize: 5242880 # default 5mb
         # the default ACL for putting objects in your s3 bucket
         ACL: 'public-read'
+        # default http timeout (match with logservice timeout)
+        httpTimeout: 20000
 
 ecosystem:
     ui: https://cd.screwdriver.cd

--- a/helpers/aws.js
+++ b/helpers/aws.js
@@ -27,7 +27,7 @@ class AwsClient {
             region: config.region,
             s3ForcePathStyle: config.forcePathStyle,
             httpOptions: {
-                timeout: config.httpTimeout
+                timeout: +config.httpTimeout
             }
         };
 

--- a/helpers/aws.js
+++ b/helpers/aws.js
@@ -18,13 +18,17 @@ class AwsClient {
      * @param  {String}    config.bucket             S3 bucket
      * @param  {String}    config.segment            S3 segment
      * @param  {Integer}   config.partSize           aws-sdk upload option
+     * @param  {Integer}   config.httpTimeout        HTTP timeout in ms
      */
     constructor(config) {
         const options = {
             accessKeyId: config.accessKeyId,
             secretAccessKey: config.secretAccessKey,
             region: config.region,
-            s3ForcePathStyle: config.forcePathStyle
+            s3ForcePathStyle: config.forcePathStyle,
+            httpOptions: {
+                timeout: config.httpTimeout
+            }
         };
 
         if (config.endpoint) {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "eslint-config-screwdriver": "^3.0.0",
     "js-yaml": "^3.6.1",
     "jsonwebtoken": "^8.4.0",
-    "mocha": "^7.0.1",
+    "mocha": "^7.2.0",
     "mockery": "^2.0.0",
     "nyc": "^15.0.0",
     "sinon": "^7.0.0"


### PR DESCRIPTION
## Context

Default timeout of 2mins doesn't match with configured timeout from log-service which is 20s

## Objective

Allow cluster admin to configure max s3 http timeout.

## References

https://github.com/screwdriver-cd/log-service/blob/master/sduploader/sdstoreuploader.go#L37

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
