### PR TITLE
feat(1958): Upgrade to @hapi/hapi v19.x.x. BREAKING CHANGE: new major data-schema

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -11,8 +11,11 @@ const strategyModule = `catbox-${strategyConfig.plugin}`;
 
 // eslint-disable-next-line import/no-dynamic-require
 const strategy = require(strategyModule);
-const cache = Object.assign({ engine: strategy }, strategyConfig[strategyConfig.plugin]);
-
+const cache = {
+    engine: new strategy({
+        ...strategyConfig[strategyConfig.plugin]
+    })
+};
 const httpd = config.get('httpd');
 const auth = config.get('auth');
 const builds = config.get('builds');

--- a/helpers/aws.js
+++ b/helpers/aws.js
@@ -2,7 +2,7 @@
 
 const AWS = require('aws-sdk');
 const stream = require('stream');
-const Boom = require('boom');
+const Boom = require('@hapi/boom');
 const logger = require('screwdriver-logger');
 
 class AwsClient {
@@ -179,8 +179,9 @@ class AwsClient {
             req.on('httpHeaders', (statusCode) => {
                 if (statusCode >= 400) {
                     logger.error(`Fetch ${cacheKey} request failed: ${statusCode}`);
+                    const error = new Error('Fetch cache request failed');
 
-                    return reject(new Boom('Fetch cache request failed', { statusCode }));
+                    return reject(Boom.boomify(error, { statusCode }));
                 }
 
                 return resolve(s3stream);

--- a/lib/server.js
+++ b/lib/server.js
@@ -34,48 +34,52 @@ const CUSTOM_PLUGINS = [
  * @return {http.Server}                            A listener: NodeJS http.Server object
  */
 module.exports = async (config) => {
-    let corsOrigins = [config.ecosystem.ui];
+    try {
+        let corsOrigins = [config.ecosystem.ui];
 
-    if (Array.isArray(config.ecosystem.allowCors)) {
-        corsOrigins = corsOrigins.concat(config.ecosystem.allowCors);
-    }
-
-    // Allow ui to query store
-    const cors = {
-        origin: corsOrigins
-    };
-
-    // Create a server with a host and port
-    // Use Object.assign to pass httpd config
-    const server = Hapi.server({
-        routes: {
-            cors,
-            log: { collect: true },
-            payload: { timeout: 60000 }
-        },
-        router: {
-            stripTrailingSlash: true
-        },
-        cache: config.cache,
-        ...config.httpd
-    });
-
-    // Register Plugins
-    /* eslint-disable */
-    const coreRegistrations = CORE_PLUGINS.map(plugin => require(plugin));
-    const customRegistrations = CUSTOM_PLUGINS.map(plugin => ({
-        plugin: require(`../plugins/${plugin}`),
-        options: config[plugin] || {}
-    }));
-    /* eslint-enable */
-
-    await server.register(coreRegistrations.concat(customRegistrations), {
-        routes: {
-            prefix: '/v1'
+        if (Array.isArray(config.ecosystem.allowCors)) {
+            corsOrigins = corsOrigins.concat(config.ecosystem.allowCors);
         }
-    });
 
-    await server.start();
+        // Allow ui to query store
+        const cors = {
+            origin: corsOrigins
+        };
 
-    return server;
+        // Create a server with a host and port
+        // Use Object.assign to pass httpd config
+        const server = Hapi.server({
+            routes: {
+                cors,
+                log: { collect: true },
+                payload: { timeout: 60000 }
+            },
+            router: {
+                stripTrailingSlash: true
+            },
+            cache: [config.cache],
+            ...config.httpd
+        });
+
+        // Register Plugins
+        /* eslint-disable */
+        const coreRegistrations = CORE_PLUGINS.map(plugin => require(plugin));
+        const customRegistrations = CUSTOM_PLUGINS.map(plugin => ({
+            plugin: require(`../plugins/${plugin}`),
+            options: config[plugin] || {}
+        }));
+        /* eslint-enable */
+
+        await server.register(coreRegistrations.concat(customRegistrations), {
+            routes: {
+                prefix: '/v1'
+            }
+        });
+
+        await server.start();
+
+        return server;
+    } catch (err) {
+        throw err;
+    }
 };

--- a/lib/server.js
+++ b/lib/server.js
@@ -34,52 +34,48 @@ const CUSTOM_PLUGINS = [
  * @return {http.Server}                            A listener: NodeJS http.Server object
  */
 module.exports = async (config) => {
-    try {
-        let corsOrigins = [config.ecosystem.ui];
+    let corsOrigins = [config.ecosystem.ui];
 
-        if (Array.isArray(config.ecosystem.allowCors)) {
-            corsOrigins = corsOrigins.concat(config.ecosystem.allowCors);
-        }
-
-        // Allow ui to query store
-        const cors = {
-            origin: corsOrigins
-        };
-
-        // Create a server with a host and port
-        // Use Object.assign to pass httpd config
-        const server = Hapi.server({
-            routes: {
-                cors,
-                log: { collect: true },
-                payload: { timeout: 60000 }
-            },
-            router: {
-                stripTrailingSlash: true
-            },
-            cache: [config.cache],
-            ...config.httpd
-        });
-
-        // Register Plugins
-        /* eslint-disable */
-        const coreRegistrations = CORE_PLUGINS.map(plugin => require(plugin));
-        const customRegistrations = CUSTOM_PLUGINS.map(plugin => ({
-            plugin: require(`../plugins/${plugin}`),
-            options: config[plugin] || {}
-        }));
-        /* eslint-enable */
-
-        await server.register(coreRegistrations.concat(customRegistrations), {
-            routes: {
-                prefix: '/v1'
-            }
-        });
-
-        await server.start();
-
-        return server;
-    } catch (err) {
-        throw err;
+    if (Array.isArray(config.ecosystem.allowCors)) {
+        corsOrigins = corsOrigins.concat(config.ecosystem.allowCors);
     }
+
+    // Allow ui to query store
+    const cors = {
+        origin: corsOrigins
+    };
+
+    // Create a server with a host and port
+    // Use Object.assign to pass httpd config
+    const server = Hapi.server({
+        routes: {
+            cors,
+            log: { collect: true },
+            payload: { timeout: 60000 }
+        },
+        router: {
+            stripTrailingSlash: true
+        },
+        cache: [config.cache],
+        ...config.httpd
+    });
+
+    // Register Plugins
+    /* eslint-disable */
+    const coreRegistrations = CORE_PLUGINS.map(plugin => require(plugin));
+    const customRegistrations = CUSTOM_PLUGINS.map(plugin => ({
+        plugin: require(`../plugins/${plugin}`),
+        options: config[plugin] || {}
+    }));
+    /* eslint-enable */
+
+    await server.register(coreRegistrations.concat(customRegistrations), {
+        routes: {
+            prefix: '/v1'
+        }
+    });
+
+    await server.start();
+
+    return server;
 };

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 const CORE_PLUGINS = [
-    'inert',
-    'vision',
+    '@hapi/inert',
+    '@hapi/vision',
     '../plugins/status',
     '../plugins/swagger',
     '../plugins/logging',

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --recursive --timeout 4000 --retries 1 --exit --allow-uncaught true --color true",
     "start": "./bin/server",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post",
-    "debug": "node --nolazy --inspect-brk=9229 ./bin/server"
+    "debug": "node --nolazy ./bin/server"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "joi": "^17.2.0",
     "mime-types": "^2.1.25",
     "request": "^2.88.0",
-    "screwdriver-data-schema": "20.0.0",
+    "screwdriver-data-schema": "^20.0.0",
     "screwdriver-logger": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-store",
-  "version": "1.0.0",
+  "version": "4.0.0",
   "description": "Pluggable Artifact Store (for logs, shared steps, templates, etc).",
   "main": "index.js",
   "scripts": {
@@ -59,27 +59,27 @@
     "sinon": "^7.0.0"
   },
   "dependencies": {
+    "@hapi/boom": "^9.1.0",
+    "@hapi/catbox": "^11.1.0",
+    "@hapi/catbox-memory": "^5.0.0",
+    "@hapi/good": "^9.0.0",
+    "@hapi/good-console": "^9.0.0",
+    "@hapi/good-squeeze": "^6.0.0",
+    "@hapi/hapi": "^19.2.0",
+    "@hapi/hoek": "^9.0.4",
+    "@hapi/inert": "^6.0.1",
+    "@hapi/vision": "^6.0.0",
     "aws-sdk": "^2.361.0",
-    "boom": "^7.2.2",
-    "catbox": "^10.0.5",
-    "catbox-disk": "^3.0.0",
-    "catbox-memory": "^3.1.4",
+    "catbox-disk": "^3.0.2",
     "catbox-s3": "^4.0.0",
     "cheerio": "^1.0.0-rc.3",
     "config": "^1.30.0",
-    "good": "^8.1.1",
-    "good-console": "^7.1.0",
-    "good-squeeze": "^5.0.2",
-    "hapi": "^17.7.0",
-    "hapi-auth-jwt2": "^8.1.0",
-    "hapi-swagger": "^9.1.3",
-    "hoek": "^5.0.3",
-    "inert": "^5.1.2",
-    "joi": "13.1.2",
+    "hapi-auth-jwt2": "^10.1.0",
+    "hapi-swagger": "^13.0.2",
+    "joi": "^17.2.0",
     "mime-types": "^2.1.25",
     "request": "^2.88.0",
-    "screwdriver-data-schema": "^18.34.2",
-    "screwdriver-logger": "^1.0.0",
-    "vision": "^5.4.3"
+    "screwdriver-data-schema": "git://github.com/screwdriver-cd/data-schema.git#hapi-v19",
+    "screwdriver-logger": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@hapi/good": "^9.0.0",
     "@hapi/good-console": "^9.0.0",
     "@hapi/good-squeeze": "^6.0.0",
-    "@hapi/hapi": "^19.2.0",
+    "@hapi/hapi": "^20.0.0",
     "@hapi/hoek": "^9.0.4",
     "@hapi/inert": "^6.0.1",
     "@hapi/vision": "^6.0.0",
@@ -79,7 +79,7 @@
     "joi": "^17.2.0",
     "mime-types": "^2.1.25",
     "request": "^2.88.0",
-    "screwdriver-data-schema": "git://github.com/screwdriver-cd/data-schema.git#hapi-v19",
+    "screwdriver-data-schema": "20.0.0",
     "screwdriver-logger": "^1.0.0"
   }
 }

--- a/plugins/builds.js
+++ b/plugins/builds.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const joi = require('joi');
-const boom = require('boom');
+const boom = require('@hapi/boom');
 const config = require('config');
 const cheerio = require('cheerio');
 
@@ -13,7 +13,7 @@ const { getMimeFromFileExtension, displableMimes, knownMimes } = require('../hel
 const SCHEMA_BUILD_ID = joi.number().integer().positive().label('Build ID');
 const SCHEMA_ARTIFACT_ID = joi.string().label('Artifact ID');
 const TYPE = joi.string().optional()
-    .valid(['download', 'preview'])
+    .valid('download', 'preview')
     .label('Flag to trigger type either to download or preview');
 const TOKEN = joi.string().label('Auth Token');
 const DEFAULT_TTL = 24 * 60 * 60 * 1000; // 1 day
@@ -132,14 +132,14 @@ exports.plugin = {
                     }
                 },
                 validate: {
-                    params: {
+                    params: joi.object({
                         id: SCHEMA_BUILD_ID,
                         artifact: SCHEMA_ARTIFACT_ID
-                    },
-                    query: {
+                    }),
+                    query: joi.object({
                         type: TYPE,
                         token: TOKEN
-                    }
+                    })
                 }
             }
         }, {
@@ -225,10 +225,10 @@ exports.plugin = {
                     }
                 },
                 validate: {
-                    params: {
+                    params: joi.object({
                         id: SCHEMA_BUILD_ID,
                         artifact: SCHEMA_ARTIFACT_ID
-                    }
+                    })
                 }
             }
         }]);

--- a/plugins/caches.js
+++ b/plugins/caches.js
@@ -1,12 +1,12 @@
 'use strict';
 
 const joi = require('joi');
-const boom = require('boom');
+const boom = require('@hapi/boom');
 const config = require('config');
 const AwsClient = require('../helpers/aws');
 const { streamToBuffer } = require('../helpers/helper');
 
-const SCHEMA_SCOPE_NAME = joi.string().valid(['events', 'jobs', 'pipelines']).label('Scope Name');
+const SCHEMA_SCOPE_NAME = joi.string().valid('events', 'jobs', 'pipelines').label('Scope Name');
 const SCHEMA_SCOPE_ID = joi.number().integer().positive().label('Event/Job/Pipeline ID');
 const SCHEMA_CACHE_NAME = joi.string().label('Cache Name');
 
@@ -153,11 +153,11 @@ exports.plugin = {
                     }
                 },
                 validate: {
-                    params: {
+                    params: joi.object({
                         scope: SCHEMA_SCOPE_NAME,
                         id: SCHEMA_SCOPE_ID,
                         cacheName: SCHEMA_CACHE_NAME
-                    }
+                    })
                 }
             }
         }, {
@@ -283,11 +283,11 @@ exports.plugin = {
                     }
                 },
                 validate: {
-                    params: {
+                    params: joi.object({
                         scope: SCHEMA_SCOPE_NAME,
                         id: SCHEMA_SCOPE_ID,
                         cacheName: SCHEMA_CACHE_NAME
-                    }
+                    })
                 }
             }
         }, {
@@ -363,11 +363,11 @@ exports.plugin = {
                     }
                 },
                 validate: {
-                    params: {
+                    params: joi.object({
                         scope: SCHEMA_SCOPE_NAME,
                         id: SCHEMA_SCOPE_ID,
                         cacheName: SCHEMA_CACHE_NAME
-                    }
+                    })
                 }
             }
         }, {
@@ -414,10 +414,10 @@ exports.plugin = {
                     }
                 },
                 validate: {
-                    params: {
+                    params: joi.object({
                         scope: SCHEMA_SCOPE_NAME,
                         id: SCHEMA_SCOPE_ID
-                    }
+                    })
                 }
             }
         }]);

--- a/plugins/commands.js
+++ b/plugins/commands.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const boom = require('boom');
+const joi = require('joi');
+const boom = require('@hapi/boom');
 const schema = require('screwdriver-data-schema');
 const SCHEMA_COMMAND_NAMESPACE = schema.config.command.namespace;
 const SCHEMA_COMMAND_NAME = schema.config.command.name;
@@ -66,11 +67,11 @@ exports.plugin = {
                     }
                 },
                 validate: {
-                    params: {
+                    params: joi.object({
                         namespace: SCHEMA_COMMAND_NAMESPACE,
                         name: SCHEMA_COMMAND_NAME,
                         version: SCHEMA_COMMAND_VERSION
-                    }
+                    })
                 }
             }
         }, {
@@ -124,11 +125,11 @@ exports.plugin = {
                     }
                 },
                 validate: {
-                    params: {
+                    params: joi.object({
                         namespace: SCHEMA_COMMAND_NAMESPACE,
                         name: SCHEMA_COMMAND_NAME,
                         version: SCHEMA_COMMAND_VERSION
-                    }
+                    })
                 }
             }
         }, {
@@ -163,11 +164,11 @@ exports.plugin = {
                     }
                 },
                 validate: {
-                    params: {
+                    params: joi.object({
                         namespace: SCHEMA_COMMAND_NAMESPACE,
                         name: SCHEMA_COMMAND_NAME,
                         version: SCHEMA_COMMAND_VERSION
-                    }
+                    })
                 }
             }
         }]);

--- a/plugins/logging.js
+++ b/plugins/logging.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const good = require('good');
+const good = require('@hapi/good');
 
 const options = {
     ops: {
@@ -8,11 +8,11 @@ const options = {
     },
     reporters: {
         console: [{
-            module: 'good-squeeze',
+            module: '@hapi/good-squeeze',
             name: 'Squeeze',
             args: [{ error: '*', log: '*', response: '*', request: '*' }]
         }, {
-            module: 'good-console'
+            module: '@hapi/good-console'
         }, 'stdout']
     }
 };

--- a/test/lib/server.test.js
+++ b/test/lib/server.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { assert } = require('chai');
-const engine = require('catbox-memory');
+const Catbox = require('@hapi/catbox-memory');
 
 describe('server case', function () {
     // Time not important. Only life important.
@@ -35,7 +35,9 @@ describe('server case', function () {
                     httpd: {
                         port: 12347
                     },
-                    cache: { engine },
+                    cache: {
+                        engine: new Catbox()
+                    },
                     auth: {
                         jwtPublicKey: '12345'
                     },
@@ -71,7 +73,9 @@ describe('server case', function () {
             httpd: {
                 port: 12347
             },
-            cache: { engine },
+            cache: {
+                engine: new Catbox()
+            },
             commands: {},
             ecosystem
         })

--- a/test/plugins/auth.test.js
+++ b/test/plugins/auth.test.js
@@ -2,7 +2,7 @@
 
 const { assert } = require('chai');
 const sinon = require('sinon');
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 const jwt = require('jsonwebtoken');
 const fs = require('fs');
 const path = require('path');

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -4,7 +4,7 @@ const { assert } = require('chai');
 const sinon = require('sinon');
 const Hapi = require('@hapi/hapi');
 const mockery = require('mockery');
-const Catmemory = require('@hapi/catbox-memory');
+const CatboxMemory = require('@hapi/catbox-memory');
 const Boom = require('@hapi/boom');
 
 const mockBuildID = 1899999;
@@ -28,7 +28,7 @@ describe('builds plugin test', () => {
 
         server = Hapi.server({
             cache: {
-                engine: new Catmemory({
+                engine: new CatboxMemory({
                     maxByteSize: 512
                 })
             },
@@ -84,7 +84,7 @@ describe('builds plugin test', () => {
             beforeEach(() => {
                 badServer = Hapi.server({
                     cache: {
-                        engine: new Catmemory({
+                        engine: new CatboxMemory({
                             maxByteSize: 9999999999
                         })
                     },
@@ -434,7 +434,7 @@ describe('builds plugin test using s3', () => {
 
         server = Hapi.server({
             cache: {
-                engine: new Catmemory({
+                engine: new CatboxMemory({
                     maxByteSize: 512
                 })
             },

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -2,10 +2,10 @@
 
 const { assert } = require('chai');
 const sinon = require('sinon');
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 const mockery = require('mockery');
-const catmemory = require('catbox-memory');
-const Boom = require('boom');
+const Catmemory = require('@hapi/catbox-memory');
+const Boom = require('@hapi/boom');
 
 const mockBuildID = 1899999;
 
@@ -28,9 +28,9 @@ describe('builds plugin test', () => {
 
         server = Hapi.server({
             cache: {
-                engine: catmemory,
-                maxByteSize: 512,
-                allowMixedContent: true
+                engine: new Catmemory({
+                    maxByteSize: 512
+                })
             },
             port: 1234
         });
@@ -66,10 +66,12 @@ describe('builds plugin test', () => {
                 headers: {
                     'x-foo': 'bar'
                 },
-                credentials: {
-                    username: mockBuildID,
-                    scope: ['user']
-                },
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        username: mockBuildID,
+                        scope: ['user']
+                    } },
                 url: `/builds/${mockBuildID}/foo`
             }).then((response) => {
                 assert.equal(response.statusCode, 404);
@@ -82,9 +84,9 @@ describe('builds plugin test', () => {
             beforeEach(() => {
                 badServer = Hapi.server({
                     cache: {
-                        engine: catmemory,
-                        maxByteSize: 9999999999,
-                        allowMixedContent: true
+                        engine: new Catmemory({
+                            maxByteSize: 9999999999
+                        })
                     },
                     port: 12345
                 });
@@ -107,10 +109,12 @@ describe('builds plugin test', () => {
                     headers: {
                         'x-foo': 'bar'
                     },
-                    credentials: {
-                        username: mockBuildID,
-                        scope: ['user']
-                    },
+                    auth: {
+                        strategy: 'token',
+                        credentials: {
+                            username: mockBuildID,
+                            scope: ['user']
+                        } },
                     url: `/builds/${mockBuildID}/foo`
                 }).then((response) => {
                     assert.equal(response.statusCode, 500);
@@ -133,10 +137,12 @@ describe('builds plugin test', () => {
                 headers: {
                     'x-foo': 'bar'
                 },
-                credentials: {
-                    username: mockBuildID,
-                    scope: ['user']
-                },
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        username: mockBuildID,
+                        scope: ['user']
+                    } },
                 url: `/builds/${mockBuildID}/foo.html`
             });
 
@@ -162,10 +168,12 @@ describe('builds plugin test', () => {
                 headers: {
                     'x-foo': 'bar'
                 },
-                credentials: {
-                    username: mockBuildID,
-                    scope: ['user']
-                },
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        username: mockBuildID,
+                        scope: ['user']
+                    } },
                 url: `/builds/${mockBuildID}/foo`
             });
 
@@ -189,10 +197,12 @@ describe('builds plugin test', () => {
                     'content-type': 'text/plain',
                     ignore: 'true'
                 },
-                credentials: {
-                    username: mockBuildID,
-                    scope: ['build']
-                }
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        username: mockBuildID,
+                        scope: ['build']
+                    } }
             };
         });
 
@@ -231,10 +241,12 @@ describe('builds plugin test', () => {
 
             const getResponse = await server.inject({
                 url: `/builds/${mockBuildID}/foo`,
-                credentials: {
-                    username: mockBuildID,
-                    scope: ['user']
-                }
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        username: mockBuildID,
+                        scope: ['user']
+                    } }
             });
 
             assert.equal(getResponse.statusCode, 200);
@@ -245,10 +257,12 @@ describe('builds plugin test', () => {
 
             const downloadResponse = await server.inject({
                 url: `/builds/${mockBuildID}/foo?type=download`,
-                credentials: {
-                    username: mockBuildID,
-                    scope: ['user']
-                }
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        username: mockBuildID,
+                        scope: ['user']
+                    } }
             });
 
             assert.equal(downloadResponse.statusCode, 200);
@@ -268,10 +282,12 @@ describe('builds plugin test', () => {
 
             const getResponse = await server.inject({
                 url: `/builds/${mockBuildID}/日本語.txt`,
-                credentials: {
-                    username: mockBuildID,
-                    scope: ['user']
-                }
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        username: mockBuildID,
+                        scope: ['user']
+                    } }
             });
 
             assert.equal(getResponse.statusCode, 200);
@@ -282,10 +298,12 @@ describe('builds plugin test', () => {
 
             const downloadResponse = await server.inject({
                 url: `/builds/${mockBuildID}/日本語.txt?type=download`,
-                credentials: {
-                    username: mockBuildID,
-                    scope: ['user']
-                }
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        username: mockBuildID,
+                        scope: ['user']
+                    } }
             });
 
             assert.equal(downloadResponse.statusCode, 200);
@@ -304,10 +322,12 @@ describe('builds plugin test', () => {
 
             return server.inject({
                 url: `/builds/${mockBuildID}/foo`,
-                credentials: {
-                    username: mockBuildID,
-                    scope: ['user']
-                }
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        username: mockBuildID,
+                        scope: ['user']
+                    } }
             }).then((getResponse) => {
                 assert.equal(getResponse.statusCode, 200);
                 assert.equal(getResponse.headers['content-type'], 'text/plain; charset=utf-8');
@@ -326,10 +346,12 @@ describe('builds plugin test', () => {
 
             return server.inject({
                 url: `/builds/${mockBuildID}/foo.html`,
-                credentials: {
-                    username: mockBuildID,
-                    scope: ['user']
-                }
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        username: mockBuildID,
+                        scope: ['user']
+                    } }
             }).then((getResponse) => {
                 assert.equal(getResponse.statusCode, 200);
                 assert.equal(getResponse.headers['content-type'], 'text/html; charset=utf-8');
@@ -349,10 +371,12 @@ describe('builds plugin test', () => {
 
             return server.inject({
                 url: `/builds/${mockBuildID}/foo`,
-                credentials: {
-                    username: mockBuildID,
-                    scope: ['pipeline']
-                }
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        username: mockBuildID,
+                        scope: ['pipeline']
+                    } }
             }).then((getResponse) => {
                 assert.equal(getResponse.statusCode, 200);
                 assert.equal(getResponse.result, 'THIS IS A TEST');
@@ -410,9 +434,9 @@ describe('builds plugin test using s3', () => {
 
         server = Hapi.server({
             cache: {
-                engine: catmemory,
-                maxByteSize: 512,
-                allowMixedContent: true
+                engine: new Catmemory({
+                    maxByteSize: 512
+                })
             },
             port: 1234
         });
@@ -448,21 +472,23 @@ describe('builds plugin test using s3', () => {
                 headers: {
                     'x-foo': 'bar'
                 },
-                credentials: {
-                    username: mockBuildID,
-                    scope: ['user']
-                },
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        username: mockBuildID,
+                        scope: ['user']
+                    } },
                 url: `/builds/${mockBuildID}/foo.zip`
             }).then((response) => {
                 assert.calledWith(getDownloadStreamMock, {
                     cacheKey: `${mockBuildID}-foo.zip`
                 });
-                assert.equal(response.statusCode, 200);
+                assert.equal(response.statusCode, 204);
             })
         ));
 
         it('returns 404 if not found', () => {
-            getDownloadStreamMock.rejects(new Boom('Not found', {
+            getDownloadStreamMock.rejects(Boom.boomify(new Error('Not found'), {
                 statusCode: 404
             }));
 
@@ -470,10 +496,12 @@ describe('builds plugin test using s3', () => {
                 headers: {
                     'x-foo': 'bar'
                 },
-                credentials: {
-                    username: mockBuildID,
-                    scope: ['user']
-                },
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        username: mockBuildID,
+                        scope: ['user']
+                    } },
                 url: `/builds/${mockBuildID}/foo.zip`
             }).then((response) => {
                 assert.calledWith(getDownloadStreamMock, {
@@ -495,10 +523,12 @@ describe('builds plugin test using s3', () => {
                     'x-foo': 'bar',
                     ignore: 'true'
                 },
-                credentials: {
-                    username: mockBuildID,
-                    scope: ['build']
-                },
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        username: mockBuildID,
+                        scope: ['build']
+                    } },
                 url: `/builds/${mockBuildID}/foo.zip`
             };
         });
@@ -513,11 +543,13 @@ describe('builds plugin test using s3', () => {
 
             return server.inject({
                 url: options.url,
-                credentials: {
-                    scope: ['user']
-                }
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        scope: ['user']
+                    } }
             }).then((getResponse) => {
-                assert.equal(getResponse.statusCode, 200);
+                assert.equal(getResponse.statusCode, 204);
                 assert.equal(getResponse.headers['content-type'], 'application/octet-stream');
                 assert.isNotOk(getResponse.headers['x-foo']);
                 assert.isNotOk(getResponse.headers.ignore);

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -71,7 +71,8 @@ describe('builds plugin test', () => {
                     credentials: {
                         username: mockBuildID,
                         scope: ['user']
-                    } },
+                    }
+                },
                 url: `/builds/${mockBuildID}/foo`
             }).then((response) => {
                 assert.equal(response.statusCode, 404);
@@ -114,7 +115,8 @@ describe('builds plugin test', () => {
                         credentials: {
                             username: mockBuildID,
                             scope: ['user']
-                        } },
+                        }
+                    },
                     url: `/builds/${mockBuildID}/foo`
                 }).then((response) => {
                     assert.equal(response.statusCode, 500);
@@ -142,7 +144,8 @@ describe('builds plugin test', () => {
                     credentials: {
                         username: mockBuildID,
                         scope: ['user']
-                    } },
+                    }
+                },
                 url: `/builds/${mockBuildID}/foo.html`
             });
 
@@ -173,7 +176,8 @@ describe('builds plugin test', () => {
                     credentials: {
                         username: mockBuildID,
                         scope: ['user']
-                    } },
+                    }
+                },
                 url: `/builds/${mockBuildID}/foo`
             });
 
@@ -202,7 +206,8 @@ describe('builds plugin test', () => {
                     credentials: {
                         username: mockBuildID,
                         scope: ['build']
-                    } }
+                    }
+                }
             };
         });
 
@@ -246,7 +251,8 @@ describe('builds plugin test', () => {
                     credentials: {
                         username: mockBuildID,
                         scope: ['user']
-                    } }
+                    }
+                }
             });
 
             assert.equal(getResponse.statusCode, 200);
@@ -262,7 +268,8 @@ describe('builds plugin test', () => {
                     credentials: {
                         username: mockBuildID,
                         scope: ['user']
-                    } }
+                    }
+                }
             });
 
             assert.equal(downloadResponse.statusCode, 200);
@@ -287,7 +294,8 @@ describe('builds plugin test', () => {
                     credentials: {
                         username: mockBuildID,
                         scope: ['user']
-                    } }
+                    }
+                }
             });
 
             assert.equal(getResponse.statusCode, 200);
@@ -303,7 +311,8 @@ describe('builds plugin test', () => {
                     credentials: {
                         username: mockBuildID,
                         scope: ['user']
-                    } }
+                    }
+                }
             });
 
             assert.equal(downloadResponse.statusCode, 200);
@@ -327,7 +336,8 @@ describe('builds plugin test', () => {
                     credentials: {
                         username: mockBuildID,
                         scope: ['user']
-                    } }
+                    }
+                }
             }).then((getResponse) => {
                 assert.equal(getResponse.statusCode, 200);
                 assert.equal(getResponse.headers['content-type'], 'text/plain; charset=utf-8');
@@ -351,7 +361,8 @@ describe('builds plugin test', () => {
                     credentials: {
                         username: mockBuildID,
                         scope: ['user']
-                    } }
+                    }
+                }
             }).then((getResponse) => {
                 assert.equal(getResponse.statusCode, 200);
                 assert.equal(getResponse.headers['content-type'], 'text/html; charset=utf-8');
@@ -376,7 +387,8 @@ describe('builds plugin test', () => {
                     credentials: {
                         username: mockBuildID,
                         scope: ['pipeline']
-                    } }
+                    }
+                }
             }).then((getResponse) => {
                 assert.equal(getResponse.statusCode, 200);
                 assert.equal(getResponse.result, 'THIS IS A TEST');
@@ -477,7 +489,8 @@ describe('builds plugin test using s3', () => {
                     credentials: {
                         username: mockBuildID,
                         scope: ['user']
-                    } },
+                    }
+                },
                 url: `/builds/${mockBuildID}/foo.zip`
             }).then((response) => {
                 assert.calledWith(getDownloadStreamMock, {
@@ -501,7 +514,8 @@ describe('builds plugin test using s3', () => {
                     credentials: {
                         username: mockBuildID,
                         scope: ['user']
-                    } },
+                    }
+                },
                 url: `/builds/${mockBuildID}/foo.zip`
             }).then((response) => {
                 assert.calledWith(getDownloadStreamMock, {
@@ -528,7 +542,8 @@ describe('builds plugin test using s3', () => {
                     credentials: {
                         username: mockBuildID,
                         scope: ['build']
-                    } },
+                    }
+                },
                 url: `/builds/${mockBuildID}/foo.zip`
             };
         });
@@ -547,7 +562,8 @@ describe('builds plugin test using s3', () => {
                     strategy: 'token',
                     credentials: {
                         scope: ['user']
-                    } }
+                    }
+                }
             }).then((getResponse) => {
                 assert.equal(getResponse.statusCode, 204);
                 assert.equal(getResponse.headers['content-type'], 'application/octet-stream');

--- a/test/plugins/caches.test.js
+++ b/test/plugins/caches.test.js
@@ -2,10 +2,10 @@
 
 const { assert } = require('chai');
 const sinon = require('sinon');
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 const mockery = require('mockery');
-const catmemory = require('catbox-memory');
-const Boom = require('boom');
+const Catmemory = require('@hapi/catbox-memory');
+const Boom = require('@hapi/boom');
 
 sinon.assert.expose(assert, { prefix: '' });
 
@@ -46,9 +46,9 @@ describe('caches plugin test using memory', () => {
 
         server = Hapi.server({
             cache: {
-                engine: catmemory,
-                maxByteSize: 512,
-                allowMixedContent: true
+                engine: new Catmemory({
+                    maxByteSize: 512
+                })
             },
             port: 1234
         });
@@ -90,9 +90,12 @@ describe('caches plugin test using memory', () => {
                 headers: {
                     'x-foo': 'bar'
                 },
-                credentials: {
-                    eventId: 5555,
-                    scope: ['build']
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        eventId: 5555,
+                        scope: ['build']
+                    }
                 },
                 url: `/caches/invalid/${mockEventID}/foo`
             }).then((response) => {
@@ -107,9 +110,12 @@ describe('caches plugin test using memory', () => {
                 headers: {
                     'x-foo': 'bar'
                 },
-                credentials: {
-                    eventId: mockEventID,
-                    scope: ['build']
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        eventId: mockEventID,
+                        scope: ['build']
+                    }
                 },
                 url: `/caches/events/${mockEventID}/foo`
             }).then((response) => {
@@ -122,9 +128,12 @@ describe('caches plugin test using memory', () => {
                 headers: {
                     'x-foo': 'bar'
                 },
-                credentials: {
-                    eventId: 5555,
-                    scope: ['build']
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        eventId: 5555,
+                        scope: ['build']
+                    }
                 },
                 url: `/caches/events/${mockEventID}/foo`
             }).then((response) => {
@@ -138,9 +147,9 @@ describe('caches plugin test using memory', () => {
             beforeEach(() => {
                 badServer = Hapi.server({
                     cache: {
-                        engine: catmemory,
-                        maxByteSize: 9999999999,
-                        allowMixedContent: true
+                        engine: new Catmemory({
+                            maxByteSize: 9999999999
+                        })
                     },
                     port: 12345
                 });
@@ -169,9 +178,12 @@ describe('caches plugin test using memory', () => {
                     headers: {
                         'x-foo': 'bar'
                     },
-                    credentials: {
-                        eventId: mockEventID,
-                        scope: ['build']
+                    auth: {
+                        strategy: 'token',
+                        credentials: {
+                            eventId: mockEventID,
+                            scope: ['build']
+                        }
                     },
                     url: `/caches/events/${mockEventID}/foo`
                 }).then((response) => {
@@ -187,9 +199,12 @@ describe('caches plugin test using memory', () => {
                 headers: {
                     'x-foo': 'bar'
                 },
-                credentials: {
-                    jobId: mockJobID,
-                    scope: ['build']
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        jobId: mockJobID,
+                        scope: ['build']
+                    }
                 },
                 url: `/caches/jobs/${mockJobID}/foo`
             }).then((response) => {
@@ -206,9 +221,12 @@ describe('caches plugin test using memory', () => {
                     'content-type': 'text/plain',
                     ignore: 'true'
                 },
-                credentials: {
-                    jobId: mockJobID,
-                    scope: ['build']
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        jobId: mockJobID,
+                        scope: ['build']
+                    }
                 }
             };
 
@@ -221,10 +239,13 @@ describe('caches plugin test using memory', () => {
 
             return server.inject({
                 url: `/caches/jobs/${mockJobID}/foo`,
-                credentials: {
-                    jobId: 5555,
-                    prParentJobId: mockJobID,
-                    scope: ['build']
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        jobId: 5555,
+                        prParentJobId: mockJobID,
+                        scope: ['build']
+                    }
                 }
             }).then((getResponse) => {
                 assert.equal(getResponse.statusCode, 200);
@@ -237,9 +258,12 @@ describe('caches plugin test using memory', () => {
                 headers: {
                     'x-foo': 'bar'
                 },
-                credentials: {
-                    jobId: 5555,
-                    scope: ['build']
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        jobId: 5555,
+                        scope: ['build']
+                    }
                 },
                 url: `/caches/jobs/${mockJobID}/foo`
             }).then((response) => {
@@ -253,9 +277,9 @@ describe('caches plugin test using memory', () => {
             beforeEach(() => {
                 badServer = Hapi.server({
                     cache: {
-                        engine: catmemory,
-                        maxByteSize: 9999999999,
-                        allowMixedContent: true
+                        engine: new Catmemory({
+                            maxByteSize: 9999999999
+                        })
                     },
                     port: 12345
                 });
@@ -284,9 +308,12 @@ describe('caches plugin test using memory', () => {
                     headers: {
                         'x-foo': 'bar'
                     },
-                    credentials: {
-                        jobId: mockJobID,
-                        scope: ['build']
+                    auth: {
+                        strategy: 'token',
+                        credentials: {
+                            jobId: mockJobID,
+                            scope: ['build']
+                        }
                     },
                     url: `/caches/jobs/${mockJobID}/foo`
                 }).then((response) => {
@@ -308,9 +335,12 @@ describe('caches plugin test using memory', () => {
                     'content-type': 'text/plain',
                     ignore: 'true'
                 },
-                credentials: {
-                    eventId: mockEventID,
-                    scope: ['build']
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        eventId: mockEventID,
+                        scope: ['build']
+                    }
                 }
             };
         });
@@ -333,9 +363,12 @@ describe('caches plugin test using memory', () => {
 
             return server.inject({
                 url: `/caches/events/${mockEventID}/foo`,
-                credentials: {
-                    eventId: mockEventID,
-                    scope: ['build']
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        eventId: mockEventID,
+                        scope: ['build']
+                    }
                 }
             }).then((getResponse) => {
                 assert.equal(getResponse.statusCode, 200);
@@ -355,9 +388,12 @@ describe('caches plugin test using memory', () => {
 
             return server.inject({
                 url: `/caches/events/${mockEventID}/foo`,
-                credentials: {
-                    eventId: mockEventID,
-                    scope: ['build']
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        eventId: mockEventID,
+                        scope: ['build']
+                    }
                 }
             }).then((getResponse) => {
                 assert.equal(getResponse.statusCode, 200);
@@ -378,9 +414,12 @@ describe('caches plugin test using memory', () => {
 
             return server.inject({
                 url: `/caches/events/${mockEventID}/foo`,
-                credentials: {
-                    eventId: mockEventID,
-                    scope: ['build']
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        eventId: mockEventID,
+                        scope: ['build']
+                    }
                 }
             }).then((getResponse) => {
                 assert.equal(getResponse.statusCode, 200);
@@ -401,9 +440,12 @@ describe('caches plugin test using memory', () => {
                     'content-type': 'text/plain',
                     ignore: 'true'
                 },
-                credentials: {
-                    jobId: mockJobID,
-                    scope: ['build']
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        jobId: mockJobID,
+                        scope: ['build']
+                    }
                 }
             };
         });
@@ -426,9 +468,12 @@ describe('caches plugin test using memory', () => {
 
             return server.inject({
                 url: `/caches/jobs/${mockJobID}/foo`,
-                credentials: {
-                    jobId: mockJobID,
-                    scope: ['build']
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        jobId: mockJobID,
+                        scope: ['build']
+                    }
                 }
             }).then((getResponse) => {
                 assert.equal(getResponse.statusCode, 200);
@@ -448,9 +493,12 @@ describe('caches plugin test using memory', () => {
 
             return server.inject({
                 url: `/caches/jobs/${mockJobID}/foo`,
-                credentials: {
-                    jobId: mockJobID,
-                    scope: ['build']
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        jobId: mockJobID,
+                        scope: ['build']
+                    }
                 }
             }).then((getResponse) => {
                 assert.equal(getResponse.statusCode, 200);
@@ -471,9 +519,12 @@ describe('caches plugin test using memory', () => {
 
             return server.inject({
                 url: `/caches/jobs/${mockJobID}/foo`,
-                credentials: {
-                    jobId: mockJobID,
-                    scope: ['build']
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        jobId: mockJobID,
+                        scope: ['build']
+                    }
                 }
             }).then((getResponse) => {
                 assert.equal(getResponse.statusCode, 200);
@@ -492,9 +543,12 @@ describe('caches plugin test using memory', () => {
                 headers: {
                     'x-foo': 'bar'
                 },
-                credentials: {
-                    eventId: mockEventID,
-                    scope: ['build']
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        eventId: mockEventID,
+                        scope: ['build']
+                    }
                 },
                 url: `/caches/events/${mockEventID}/foo`
             };
@@ -506,9 +560,12 @@ describe('caches plugin test using memory', () => {
                     'content-type': 'text/plain',
                     ignore: 'true'
                 },
-                credentials: {
-                    eventId: mockEventID,
-                    scope: ['build']
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        eventId: mockEventID,
+                        scope: ['build']
+                    }
                 },
                 url: `/caches/events/${mockEventID}/foo`
             };
@@ -519,9 +576,12 @@ describe('caches plugin test using memory', () => {
                     'content-type': 'text/plain',
                     ignore: 'true'
                 },
-                credentials: {
-                    eventId: mockEventID,
-                    scope: ['build']
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        eventId: mockEventID,
+                        scope: ['build']
+                    }
                 },
                 url: `/caches/events/${mockEventID}/foo`
             };
@@ -536,7 +596,7 @@ describe('caches plugin test using memory', () => {
         }));
 
         it('returns 403 if credentials is not valid', () => {
-            deleteOptions.credentials.eventId = 5555;
+            deleteOptions.auth.credentials.eventId = 5555;
 
             return server.inject(deleteOptions).then((response) => {
                 assert.equal(response.statusCode, 403);
@@ -570,9 +630,12 @@ describe('caches plugin test using memory', () => {
                 headers: {
                     'x-foo': 'bar'
                 },
-                credentials: {
-                    jobId: mockJobID,
-                    scope: ['build']
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        jobId: mockJobID,
+                        scope: ['build']
+                    }
                 },
                 url: `/caches/jobs/${mockJobID}/foo`
             };
@@ -584,9 +647,12 @@ describe('caches plugin test using memory', () => {
                     'content-type': 'text/plain',
                     ignore: 'true'
                 },
-                credentials: {
-                    jobId: mockJobID,
-                    scope: ['build']
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        jobId: mockJobID,
+                        scope: ['build']
+                    }
                 },
                 url: `/caches/jobs/${mockJobID}/foo`
             };
@@ -597,9 +663,12 @@ describe('caches plugin test using memory', () => {
                     'content-type': 'text/plain',
                     ignore: 'true'
                 },
-                credentials: {
-                    jobId: mockJobID,
-                    scope: ['build']
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        jobId: mockJobID,
+                        scope: ['build']
+                    }
                 },
                 url: `/caches/jobs/${mockJobID}/foo`
             };
@@ -614,7 +683,7 @@ describe('caches plugin test using memory', () => {
         }));
 
         it('returns 403 if credentials is not valid', () => {
-            deleteOptions.credentials.jobId = 5555;
+            deleteOptions.auth.credentials.jobId = 5555;
 
             return server.inject(deleteOptions).then((response) => {
                 assert.equal(response.statusCode, 403);
@@ -649,22 +718,25 @@ describe('caches plugin test using memory', () => {
                     'content-type': 'text/plain',
                     ignore: 'true'
                 },
-                credentials: {
-                    username: 'testuser',
-                    scope: ['sdapi']
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        username: 'testuser',
+                        scope: ['sdapi']
+                    }
                 },
                 url: `/caches/jobs/${mockJobID}`
             };
         });
 
-        it('Returns 200 if successfully invalidate cache', () => {
+        it('Returns 204 if successfully invalidate cache', () => {
             reqMock.yieldsAsync(null, {
                 statusCode: 200,
                 body: true
             });
 
             return server.inject(deleteOptions).then((deleteResponse) => {
-                assert.equal(deleteResponse.statusCode, 200);
+                assert.equal(deleteResponse.statusCode, 204);
             });
         });
 
@@ -674,7 +746,7 @@ describe('caches plugin test using memory', () => {
                 body: true
             });
 
-            deleteOptions.credentials = {
+            deleteOptions.auth.credentials = {
                 username: 'testuser',
                 scope: ['user']
             };
@@ -731,9 +803,9 @@ describe('caches plugin test using s3', () => {
 
         server = Hapi.server({
             cache: {
-                engine: catmemory,
-                maxByteSize: 512,
-                allowMixedContent: true
+                engine: new Catmemory({
+                    maxByteSize: 512
+                })
             },
             port: 1234
         });
@@ -770,26 +842,29 @@ describe('caches plugin test using s3', () => {
     });
 
     describe('GET /caches/events/:id/:cacheName', () => {
-        it('returns 200', () => (
+        it('returns 204', () => (
             server.inject({
                 headers: {
                     'x-foo': 'bar'
                 },
-                credentials: {
-                    eventId: mockEventID,
-                    scope: ['build']
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        eventId: mockEventID,
+                        scope: ['build']
+                    }
                 },
                 url: `/caches/events/${mockEventID}/foo.zip`
             }).then((response) => {
                 assert.calledWith(getDownloadStreamMock, {
                     cacheKey: `events/${mockEventID}/foo.zip`
                 });
-                assert.equal(response.statusCode, 200);
+                assert.equal(response.statusCode, 204);
             })
         ));
 
         it('returns 404 if not found', () => {
-            getDownloadStreamMock.rejects(new Boom('Not found', {
+            getDownloadStreamMock.rejects(Boom.boomify(new Error('Not found'), {
                 statusCode: 404
             }));
 
@@ -797,9 +872,12 @@ describe('caches plugin test using s3', () => {
                 headers: {
                     'x-foo': 'bar'
                 },
-                credentials: {
-                    eventId: mockEventID,
-                    scope: ['build']
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        eventId: mockEventID,
+                        scope: ['build']
+                    }
                 },
                 url: `/caches/events/${mockEventID}/foo.zip`
             }).then((response) => {
@@ -823,9 +901,12 @@ describe('caches plugin test using s3', () => {
                     'content-type': 'text/plain',
                     ignore: 'true'
                 },
-                credentials: {
-                    eventId: mockEventID,
-                    scope: ['build']
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        eventId: mockEventID,
+                        scope: ['build']
+                    }
                 }
             };
         });
@@ -839,12 +920,15 @@ describe('caches plugin test using s3', () => {
 
             return server.inject({
                 url: `/caches/events/${mockEventID}/foo.zip`,
-                credentials: {
-                    eventId: mockEventID,
-                    scope: ['build']
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        eventId: mockEventID,
+                        scope: ['build']
+                    }
                 }
             }).then((getResponse) => {
-                assert.equal(getResponse.statusCode, 200);
+                assert.equal(getResponse.statusCode, 204);
                 assert.equal(getResponse.headers['content-type'], 'application/octet-stream');
                 assert.isNotOk(getResponse.headers['x-foo']);
                 assert.isNotOk(getResponse.headers.ignore);
@@ -873,9 +957,12 @@ describe('caches plugin test using s3', () => {
                     'content-type': 'text/plain',
                     ignore: 'true'
                 },
-                credentials: {
-                    username: 'testuser',
-                    scope: ['sdapi']
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        username: 'testuser',
+                        scope: ['sdapi']
+                    }
                 },
                 url: `/caches/jobs/${mockJobID}`
             };
@@ -908,7 +995,7 @@ describe('caches plugin test using s3', () => {
         });
 
         it('Returns 403 if auth scope is different', () => {
-            deleteOptions.credentials = {
+            deleteOptions.auth.credentials = {
                 username: 'testuser',
                 scope: ['user']
             };

--- a/test/plugins/caches.test.js
+++ b/test/plugins/caches.test.js
@@ -4,7 +4,7 @@ const { assert } = require('chai');
 const sinon = require('sinon');
 const Hapi = require('@hapi/hapi');
 const mockery = require('mockery');
-const Catmemory = require('@hapi/catbox-memory');
+const CatboxMemory = require('@hapi/catbox-memory');
 const Boom = require('@hapi/boom');
 
 sinon.assert.expose(assert, { prefix: '' });
@@ -46,7 +46,7 @@ describe('caches plugin test using memory', () => {
 
         server = Hapi.server({
             cache: {
-                engine: new Catmemory({
+                engine: new CatboxMemory({
                     maxByteSize: 512
                 })
             },
@@ -147,7 +147,7 @@ describe('caches plugin test using memory', () => {
             beforeEach(() => {
                 badServer = Hapi.server({
                     cache: {
-                        engine: new Catmemory({
+                        engine: new CatboxMemory({
                             maxByteSize: 9999999999
                         })
                     },
@@ -277,7 +277,7 @@ describe('caches plugin test using memory', () => {
             beforeEach(() => {
                 badServer = Hapi.server({
                     cache: {
-                        engine: new Catmemory({
+                        engine: new CatboxMemory({
                             maxByteSize: 9999999999
                         })
                     },
@@ -803,7 +803,7 @@ describe('caches plugin test using s3', () => {
 
         server = Hapi.server({
             cache: {
-                engine: new Catmemory({
+                engine: new CatboxMemory({
                     maxByteSize: 512
                 })
             },

--- a/test/plugins/commands.test.js
+++ b/test/plugins/commands.test.js
@@ -2,9 +2,9 @@
 
 const { assert } = require('chai');
 const sinon = require('sinon');
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 const mockery = require('mockery');
-const catmemory = require('catbox-memory');
+const Catmemory = require('@hapi/catbox-memory');
 
 sinon.assert.expose(assert, { prefix: '' });
 
@@ -22,15 +22,15 @@ describe('commands plugin test', () => {
         });
     });
 
-    beforeEach(() => {
+    beforeEach(async () => {
         // eslint-disable-next-line global-require
         plugin = require('../../plugins/commands');
 
         server = Hapi.server({
             cache: {
-                engine: catmemory,
-                maxByteSize: 512,
-                allowMixedContent: true
+                engine: new Catmemory({
+                    maxByteSize: 512
+                })
             },
             port: 1234
         });
@@ -41,8 +41,8 @@ describe('commands plugin test', () => {
         server.auth.strategy('token', 'custom');
         server.auth.strategy('session', 'custom');
 
-        return server.register({ plugin })
-            .then(() => server.start());
+        await server.register({ plugin });
+        await server.start();
     });
 
     afterEach(async () => {
@@ -66,8 +66,11 @@ describe('commands plugin test', () => {
                 headers: {
                     'x-foo': 'bar'
                 },
-                credentials: {
-                    scope: ['user']
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        scope: ['user']
+                    }
                 },
                 url: `/commands/${mockCommandNamespace}/foo/0.0`
             }).then((response) => {
@@ -81,9 +84,9 @@ describe('commands plugin test', () => {
             beforeEach(() => {
                 badServer = Hapi.server({
                     cache: {
-                        engine: catmemory,
-                        maxByteSize: 9999999999,
-                        allowMixedContent: true
+                        engine: new Catmemory({
+                            maxByteSize: 9999999999
+                        })
                     },
                     port: 12345
                 });
@@ -106,8 +109,11 @@ describe('commands plugin test', () => {
                     headers: {
                         'x-foo': 'bar'
                     },
-                    credentials: {
-                        scope: ['user']
+                    auth: {
+                        strategy: 'token',
+                        credentials: {
+                            scope: ['user']
+                        }
                     },
                     url: `/commands/${mockCommandNamespace}/`
                         + `${mockCommandName}/${mockCommandVersion}`
@@ -130,16 +136,19 @@ describe('commands plugin test', () => {
                     'content-type': 'text/plain',
                     ignore: 'true'
                 },
-                credentials: {
-                    scope: ['build'],
-                    pipelineId: 123
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        scope: ['build'],
+                        pipelineId: 123
+                    }
                 }
             };
         });
 
-        it('returns 403 if wrong creds', () => {
+        it('returns 403 if wrong `cred`s', () => {
             options.url = '/commands/foo/bar/1.2.3';
-            options.credentials.scope = ['user'];
+            options.auth.credentials.scope = ['user'];
 
             return server.inject(options).then((response) => {
                 assert.equal(response.statusCode, 403);
@@ -168,12 +177,15 @@ describe('commands plugin test', () => {
 
             return server.inject({
                 url: `/commands/${mockCommandNamespace}/`
-                + `${mockCommandName}/${mockCommandVersion}`,
+                    + `${mockCommandName}/${mockCommandVersion}`,
                 headers: {
                     'x-foo': 'bar'
                 },
-                credentials: {
-                    scope: ['user']
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        scope: ['user']
+                    }
                 }
             }).then((getResponse) => {
                 assert.equal(getResponse.statusCode, 200);
@@ -195,8 +207,11 @@ describe('commands plugin test', () => {
                 headers: {
                     'x-foo': 'bar'
                 },
-                credentials: {
-                    scope: ['user']
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        scope: ['user']
+                    }
                 },
                 url: `/commands/${mockCommandNamespace}/foo/1.2.5`
             };
@@ -208,9 +223,12 @@ describe('commands plugin test', () => {
                     'content-type': 'text/plain',
                     ignore: 'true'
                 },
-                credentials: {
-                    scope: ['build'],
-                    pipelineId: 123
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        scope: ['build'],
+                        pipelineId: 123
+                    }
                 },
                 url: `/commands/${mockCommandNamespace}/foo/1.2.5`
             };
@@ -221,8 +239,11 @@ describe('commands plugin test', () => {
                     'content-type': 'text/plain',
                     ignore: 'true'
                 },
-                credentials: {
-                    scope: ['user']
+                auth: {
+                    strategy: 'token',
+                    credentials: {
+                        scope: ['user']
+                    }
                 },
                 url: `/commands/${mockCommandNamespace}/foo/1.2.5`
             };

--- a/test/plugins/commands.test.js
+++ b/test/plugins/commands.test.js
@@ -4,7 +4,7 @@ const { assert } = require('chai');
 const sinon = require('sinon');
 const Hapi = require('@hapi/hapi');
 const mockery = require('mockery');
-const Catmemory = require('@hapi/catbox-memory');
+const CatboxMemory = require('@hapi/catbox-memory');
 
 sinon.assert.expose(assert, { prefix: '' });
 
@@ -28,7 +28,7 @@ describe('commands plugin test', () => {
 
         server = Hapi.server({
             cache: {
-                engine: new Catmemory({
+                engine: new CatboxMemory({
                     maxByteSize: 512
                 })
             },
@@ -84,7 +84,7 @@ describe('commands plugin test', () => {
             beforeEach(() => {
                 badServer = Hapi.server({
                     cache: {
-                        engine: new Catmemory({
+                        engine: new CatboxMemory({
                             maxByteSize: 9999999999
                         })
                     },

--- a/test/plugins/logging.test.js
+++ b/test/plugins/logging.test.js
@@ -2,8 +2,7 @@
 
 const { assert } = require('chai');
 const sinon = require('sinon');
-const Hapi = require('hapi');
-const mockery = require('mockery');
+const Hapi = require('@hapi/hapi');
 
 sinon.assert.expose(assert, { prefix: '' });
 
@@ -11,35 +10,22 @@ describe('logging plugin test', () => {
     let plugin;
     let server;
 
-    before(() => {
-        mockery.enable({
-            useCleanCache: true,
-            warnOnUnregistered: false
-        });
-    });
-
-    beforeEach(() => {
+    beforeEach(async () => {
         // eslint-disable-next-line global-require
         plugin = require('../../plugins/logging');
 
-        server = Hapi.server({
+        server = await Hapi.server({
             port: 1234
         });
 
-        return server.register([plugin]);
+        return server.register(plugin);
     });
 
     afterEach(() => {
         server = null;
-        mockery.deregisterAll();
-        mockery.resetCache();
-    });
-
-    after(() => {
-        mockery.disable();
     });
 
     it('registers the plugin', () => {
-        assert.isOk(server.registrations.good);
+        assert.isOk(server.registrations['@hapi/good']);
     });
 });

--- a/test/plugins/stats.test.js
+++ b/test/plugins/stats.test.js
@@ -2,7 +2,7 @@
 
 const { assert } = require('chai');
 const sinon = require('sinon');
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 const mockery = require('mockery');
 
 sinon.assert.expose(assert, { prefix: '' });

--- a/test/plugins/status.test.js
+++ b/test/plugins/status.test.js
@@ -2,7 +2,7 @@
 
 const { assert } = require('chai');
 const sinon = require('sinon');
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 const mockery = require('mockery');
 
 sinon.assert.expose(assert, { prefix: '' });

--- a/test/plugins/swagger.test.js
+++ b/test/plugins/swagger.test.js
@@ -2,7 +2,7 @@
 
 const { assert } = require('chai');
 const sinon = require('sinon');
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 const mockery = require('mockery');
 
 sinon.assert.expose(assert, { prefix: '' });


### PR DESCRIPTION
## Context

Screwdriver hapi.js dependencies are outdated and not supported anymore.

## Objective

This PR majorly upgrades @hapi/hapi version and other changes to be compatible with latest @hapi js dependencies.

## References

https://github.com/screwdriver-cd/screwdriver/issues/1958

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
