### PR TITLE
fix: s3 object ACL should be private by default

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -72,8 +72,8 @@ strategy:
         forcePathStyle: false
         # aws-sdk options for the size in bytes for each individual part to be uploaded.
         partSize: 5242880 # default 5mb
-        # the default ACL for putting objects in your s3 bucket
-        ACL: 'public-read'
+        # AWS s3 object ACL should be "private" by default, unless "public-read" otherwise
+        ACL: private
         # default http timeout in ms, default 20s
         httpTimeout: 20000
 


### PR DESCRIPTION
## Context

s3 object ACL should be private by default, meaning only the owner has the full control

## Objective

this PR fixes the default value of ACL which got passed to catbox-s3 plugin

## References

https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
