### PR TITLE
fix: always use aws cli for s3.

### DIFF
--- a/plugins/builds.js
+++ b/plugins/builds.js
@@ -60,7 +60,7 @@ exports.plugin = {
                 let response;
 
                 // for old json files, the value is hidden in an object, we cannot stream it directly
-                if (usingS3 && id.endsWith('.zip')) {
+                if (usingS3) {
                     try {
                         value = await awsClient.getDownloadStream({ cacheKey: id });
                         response = h.response(value);

--- a/test/helpers/aws.test.js
+++ b/test/helpers/aws.test.js
@@ -64,7 +64,7 @@ describe('aws helper test', () => {
         mockery.registerMock('aws-sdk', sdkMock);
 
         // eslint-disable-next-line global-require
-        AwsClient = require('../../helpers/aws.js');
+        AwsClient = require('../../helpers/aws');
         awsClient = new AwsClient({
             accessKeyId,
             secretAccessKey,


### PR DESCRIPTION
## Context

When downloading files above 1G Store is going OOM

## Objective

When downloading files from Store output should be streamed.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
