### PR TITLE
fix(): when using s3, parse stream output to buffer for html files

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -47,7 +47,7 @@ async function init() {
 
         return logger.info('Server running at %s', server.info.uri);
     } catch (err) {
-        logger.error(err);
+        logger.error(err.toString());
 
         return process.exit(1);
     }

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -62,6 +62,8 @@ strategy:
         accessKeyId: null
         # Amazon secret access key
         secretAccessKey: null
+        # Amazon Session Token from federated credentials
+        sessionToken: null
         # Amazon S3 region
         region: YOUR-REGION
         # Amazon S3 bucket that you have write access to

--- a/helpers/aws.js
+++ b/helpers/aws.js
@@ -19,6 +19,7 @@ class AwsClient {
      * @param  {String}    config.segment            S3 segment
      * @param  {Integer}   config.partSize           aws-sdk upload option
      * @param  {Integer}   config.httpTimeout        HTTP timeout in ms
+     * @param  {String }   config.sessionToken       Session token for federated AWS login
      */
     constructor(config) {
         const options = {
@@ -30,6 +31,10 @@ class AwsClient {
                 timeout: +config.httpTimeout
             }
         };
+
+        if (config.sessionToken) {
+            options.sessionToken = config.sessionToken;
+        }
 
         if (config.endpoint) {
             options.endpoint = config.endpoint;

--- a/helpers/mime.js
+++ b/helpers/mime.js
@@ -14,7 +14,7 @@ const FORCE_EXTENSION_MAPPING = {
  * @return {String} text/html
  */
 function getMimeFromFileExtension(fileExtension) {
-    return mime.lookup(fileExtension) || mime.lookup(FORCE_EXTENSION_MAPPING[fileExtension]) || '';
+    return mime.lookup(FORCE_EXTENSION_MAPPING[fileExtension] || fileExtension) || '';
 }
 
 const knownMimes = ['text/css', 'text/javascript', 'image/png', 'image/jpeg', 'application/json',

--- a/helpers/mime.js
+++ b/helpers/mime.js
@@ -2,13 +2,19 @@
 
 const mime = require('mime-types');
 
+const FORCE_EXTENSION_MAPPING = {
+    yidf: 'txt',
+    state: 'txt',
+    diff: 'txt'
+};
+
 /**
  * getMimeFromFileExtension
  * @param  {String} fileExtension  File extension (e.g. css, txt, html)
  * @return {String} text/html
  */
 function getMimeFromFileExtension(fileExtension) {
-    return mime.lookup(fileExtension) || '';
+    return mime.lookup(fileExtension) || mime.lookup(FORCE_EXTENSION_MAPPING[fileExtension]) || '';
 }
 
 const knownMimes = ['text/css', 'text/javascript', 'image/png', 'image/jpeg', 'application/json',

--- a/plugins/auth.js
+++ b/plugins/auth.js
@@ -36,7 +36,7 @@ exports.plugin = {
             key: pluginOptions.jwtPublicKey,
             verifyOptions: {
                 algorithms: ['RS256'],
-                maxAge: '12h'
+                maxAge: '13h'
             },
             // This function is run once the Token has been decoded with signature
             validate

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -14,6 +14,7 @@ sinon.assert.expose(assert, { prefix: '' });
 describe('builds plugin test', () => {
     let plugin;
     let server;
+    let configMock;
 
     before(() => {
         mockery.enable({
@@ -23,6 +24,13 @@ describe('builds plugin test', () => {
     });
 
     beforeEach(() => {
+        configMock = {
+            get: sinon.stub().returns({
+                plugin: 'memory',
+                s3: {}
+            })
+        };
+        mockery.registerMock('config', configMock);
         // eslint-disable-next-line global-require
         plugin = require('../../plugins/builds');
 


### PR DESCRIPTION


## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective

1. increase token timeout to 13hrs
2. map yidf/state to txt extension
3. make sure html files can be rendered when using s3


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
