### PR TITLE
fix: force xml as text so that it's displayed in Chrome

### DIFF
--- a/helpers/mime.js
+++ b/helpers/mime.js
@@ -5,7 +5,8 @@ const mime = require('mime-types');
 const FORCE_EXTENSION_MAPPING = {
     yidf: 'txt',
     state: 'txt',
-    diff: 'txt'
+    diff: 'txt',
+    xml: 'txt' // FIXME: Chrome is not displaying xml files
 };
 
 /**


### PR DESCRIPTION
## Context

Chrome is not displaying xml file with error "Resource interpreted as Document but transferred with MIME type application/xml"

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
