### PR TITLE
fix: add yaml to MIME types

### DIFF
--- a/helpers/mime.js
+++ b/helpers/mime.js
@@ -6,6 +6,7 @@ const FORCE_EXTENSION_MAPPING = {
     yidf: 'txt',
     state: 'txt',
     diff: 'txt',
+    yaml: 'txt',
     xml: 'txt' // FIXME: Chrome is not displaying xml files
 };
 

--- a/helpers/mime.js
+++ b/helpers/mime.js
@@ -6,7 +6,6 @@ const FORCE_EXTENSION_MAPPING = {
     yidf: 'txt',
     state: 'txt',
     diff: 'txt',
-    yaml: 'txt',
     xml: 'txt' // FIXME: Chrome is not displaying xml files
 };
 
@@ -20,7 +19,7 @@ function getMimeFromFileExtension(fileExtension) {
 }
 
 const knownMimes = ['text/css', 'text/javascript', 'image/png', 'image/jpeg', 'application/json',
-    'text/plain', 'application/xml'];
+    'text/plain', 'application/xml', 'text/yaml'];
 const displayableMimes = ['text/html'];
 
 module.exports = {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
~To display yaml as text file, so we need to return type as `text/yaml` instead~

Add `add text/yaml to know MIME types

## Objective
<!-- What does this PR fix? What intentional changes will this PR make? -->

Instead of `application/octet-stream` during preview mode for `yaml` files, we want to return the type as `text/yaml`, so that it can be displayed in UI's artifacts preview window
![image](https://user-images.githubusercontent.com/15989893/119383445-310d8880-bc78-11eb-93e0-6de6ab638798.png)

Because `application/*` will be treated as binary, thus trigger downloads

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
