### PR TITLE
fix: update MIME types

### DIFF
--- a/helpers/mime.js
+++ b/helpers/mime.js
@@ -14,6 +14,7 @@ const KNOWN_FILE_EXTS_IN_TEXT_FORMAT = [
     'java',
     'lua',
     'pl',
+    'go',
     'py',
     'tox',
     'env',
@@ -23,6 +24,7 @@ const KNOWN_FILE_EXTS_IN_TEXT_FORMAT = [
     'yidf',
     'state',
     'diff',
+    'deps',
     'xml'
 ];
 

--- a/helpers/mime.js
+++ b/helpers/mime.js
@@ -2,20 +2,46 @@
 
 const mime = require('mime-types');
 
-const FORCE_EXTENSION_MAPPING = {
-    yidf: 'txt',
-    state: 'txt',
-    diff: 'txt',
-    xml: 'txt' // FIXME: Chrome is not displaying xml files
-};
+const KNOW_FILE_NAMES_IN_TEXT_FORMAT = ['dockerfile', 'makefile'];
+const KNOW_FILE_EXTS_IN_TEXT_FORMAT = [
+    'js',
+    'c',
+    'cpp',
+    'cs',
+    'dtd',
+    'h',
+    'm',
+    'java',
+    'lua',
+    'pl',
+    'py',
+    'tox',
+    'env',
+    'sh',
+    'vb',
+    'swift',
+    'yidf',
+    'state',
+    'diff',
+    'xml'
+];
 
 /**
  * getMimeFromFileExtension
  * @param  {String} fileExtension  File extension (e.g. css, txt, html)
- * @return {String} text/html
+ * @param  {String} fileName       File name      (e.g. dockerfile, main)
+ * @return {String} MIME Type      eg. text/html, text/plain
  */
-function getMimeFromFileExtension(fileExtension) {
-    return mime.lookup(FORCE_EXTENSION_MAPPING[fileExtension] || fileExtension) || '';
+function getMimeFromFileExtension(fileExtension, fileName = '') {
+    if (KNOW_FILE_NAMES_IN_TEXT_FORMAT.includes(fileName.toLowerCase())) {
+        return 'text/plain';
+    }
+
+    if (KNOW_FILE_EXTS_IN_TEXT_FORMAT.includes(fileExtension.toLowerCase())) {
+        return 'text/plain';
+    }
+
+    return mime.lookup(fileExtension) || '';
 }
 
 const knownMimes = ['text/css', 'text/javascript', 'image/png', 'image/jpeg', 'application/json',

--- a/helpers/mime.js
+++ b/helpers/mime.js
@@ -45,12 +45,9 @@ function getMimeFromFileName(fileExtension, fileName = '') {
     return mime.lookup(fileExtension) || '';
 }
 
-const knownMimes = ['text/css', 'text/javascript', 'image/png', 'image/jpeg', 'application/json',
-    'text/plain', 'application/xml', 'text/yaml'];
 const displayableMimes = ['text/html'];
 
 module.exports = {
     getMimeFromFileName,
-    displayableMimes,
-    knownMimes
+    displayableMimes
 };

--- a/helpers/mime.js
+++ b/helpers/mime.js
@@ -27,12 +27,13 @@ const KNOWN_FILE_EXTS_IN_TEXT_FORMAT = [
 ];
 
 /**
- * getMimeFromFileExtension
+ * Get MIME types from file name and file extension
+ * @method getMimeFromFileName
  * @param  {String} fileExtension  File extension (e.g. css, txt, html)
  * @param  {String} fileName       File name      (e.g. dockerfile, main)
  * @return {String} MIME Type      eg. text/html, text/plain
  */
-function getMimeFromFileExtension(fileExtension, fileName = '') {
+function getMimeFromFileName(fileExtension, fileName = '') {
     if (KNOWN_FILE_NAMES_IN_TEXT_FORMAT.includes(fileName.toLowerCase())) {
         return 'text/plain';
     }
@@ -49,7 +50,7 @@ const knownMimes = ['text/css', 'text/javascript', 'image/png', 'image/jpeg', 'a
 const displayableMimes = ['text/html'];
 
 module.exports = {
-    getMimeFromFileExtension,
+    getMimeFromFileName,
     displayableMimes,
     knownMimes
 };

--- a/helpers/mime.js
+++ b/helpers/mime.js
@@ -2,7 +2,6 @@
 
 const mime = require('mime-types');
 
-const KNOWN_FILE_NAMES_IN_TEXT_FORMAT = ['dockerfile', 'makefile'];
 const KNOWN_FILE_EXTS_IN_TEXT_FORMAT = [
     'js',
     'c',
@@ -36,7 +35,7 @@ const KNOWN_FILE_EXTS_IN_TEXT_FORMAT = [
  * @return {String} MIME Type      eg. text/html, text/plain
  */
 function getMimeFromFileName(fileExtension, fileName = '') {
-    if (KNOWN_FILE_NAMES_IN_TEXT_FORMAT.includes(fileName.toLowerCase())) {
+    if (fileName.toLowerCase().endsWith('file')) {
         return 'text/plain';
     }
 

--- a/helpers/mime.js
+++ b/helpers/mime.js
@@ -2,8 +2,8 @@
 
 const mime = require('mime-types');
 
-const KNOW_FILE_NAMES_IN_TEXT_FORMAT = ['dockerfile', 'makefile'];
-const KNOW_FILE_EXTS_IN_TEXT_FORMAT = [
+const KNOWN_FILE_NAMES_IN_TEXT_FORMAT = ['dockerfile', 'makefile'];
+const KNOWN_FILE_EXTS_IN_TEXT_FORMAT = [
     'js',
     'c',
     'cpp',
@@ -33,11 +33,11 @@ const KNOW_FILE_EXTS_IN_TEXT_FORMAT = [
  * @return {String} MIME Type      eg. text/html, text/plain
  */
 function getMimeFromFileExtension(fileExtension, fileName = '') {
-    if (KNOW_FILE_NAMES_IN_TEXT_FORMAT.includes(fileName.toLowerCase())) {
+    if (KNOWN_FILE_NAMES_IN_TEXT_FORMAT.includes(fileName.toLowerCase())) {
         return 'text/plain';
     }
 
-    if (KNOW_FILE_EXTS_IN_TEXT_FORMAT.includes(fileExtension.toLowerCase())) {
+    if (KNOWN_FILE_EXTS_IN_TEXT_FORMAT.includes(fileExtension.toLowerCase())) {
         return 'text/plain';
     }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -75,7 +75,12 @@ module.exports = async (config) => {
         }
     });
 
-    await server.start();
+    try {
+        await server.start();
+    } catch (err) {
+        console.error('err', err);
+    }
+
 
     return server;
 };

--- a/lib/server.js
+++ b/lib/server.js
@@ -81,6 +81,5 @@ module.exports = async (config) => {
         console.error('err', err);
     }
 
-
     return server;
 };

--- a/plugins/builds.js
+++ b/plugins/builds.js
@@ -8,7 +8,7 @@ const cheerio = require('cheerio');
 const AwsClient = require('../helpers/aws');
 const { iframeScript } = require('../helpers/iframe');
 const { streamToBuffer } = require('../helpers/helper');
-const { getMimeFromFileExtension, displayableMimes, knownMimes } = require('../helpers/mime');
+const { getMimeFromFileName, displayableMimes, knownMimes } = require('../helpers/mime');
 
 const SCHEMA_BUILD_ID = joi.number().integer().positive().label('Build ID');
 const SCHEMA_ARTIFACT_ID = joi.string().label('Artifact ID');
@@ -97,7 +97,7 @@ exports.plugin = {
 
                 const fileName = artifact.split('/').pop();
                 const fileExt = fileName.split('.').pop();
-                const mime = getMimeFromFileExtension(fileExt, fileName);
+                const mime = getMimeFromFileName(fileExt, fileName);
 
                 // only if the artifact is requested as downloadable item
                 if (request.query.type === 'download') {

--- a/plugins/builds.js
+++ b/plugins/builds.js
@@ -97,7 +97,7 @@ exports.plugin = {
 
                 const fileName = artifact.split('/').pop();
                 const fileExt = fileName.split('.').pop();
-                const mime = getMimeFromFileExtension(fileExt);
+                const mime = getMimeFromFileExtension(fileExt, fileName);
 
                 // only if the artifact is requested as downloadable item
                 if (request.query.type === 'download') {

--- a/plugins/builds.js
+++ b/plugins/builds.js
@@ -86,17 +86,10 @@ exports.plugin = {
                         response.headers = value.h;
                     } else {
                         response = h.response(Buffer.from(value));
-                        response.headers['content-type'] = 'text/plain';
-                    }
-
-                    if (id.endsWith('.html')) {
-                        response.headers['content-type'] = 'text/html';
                     }
                 }
 
                 const fileName = artifact.split('/').pop();
-                const fileExt = fileName.split('.').pop();
-                const mime = getMimeFromFileName(fileExt, fileName);
 
                 // only if the artifact is requested as downloadable item
                 if (request.query.type === 'download') {
@@ -104,6 +97,11 @@ exports.plugin = {
                     response.headers['content-disposition'] =
                         `attachment; filename="${encodeURI(fileName)}"`;
                 } else if (request.query.type === 'preview') {
+                    const fileExt = fileName.split('.').pop();
+                    const mime = getMimeFromFileName(fileExt, fileName);
+
+                    response.headers['content-type'] = mime;
+
                     if (displayableMimes.includes(mime)) {
                         let htmlContent;
 
@@ -118,10 +116,7 @@ exports.plugin = {
                         // inject postMessage into code
                         $('body').append(scriptNode);
                         response = h.response($.html());
-                        response.headers['content-type'] = mime;
                     } else {
-                        // let browser sniff from the filename
-                        response.headers['content-type'] = '';
                         response.headers['content-disposition'] =
                         `inline; filename="${encodeURI(fileName)}"`;
                     }

--- a/test/plugins/data/helloworld.html
+++ b/test/plugins/data/helloworld.html
@@ -1,0 +1,103 @@
+<html><head></head><body>HELLO WORLD<script>
+    function isAbsolutePath(href) {
+        const absolutePath = new RegExp('^((http|https)://|#)');
+        return absolutePath.test(href);
+    };
+
+    function maskWithAPI(apiUrlOrigin, apiVersion, urlFileDir, originalHref) {
+        const newUrl = apiUrlOrigin + '/' + apiVersion + '/' + urlFileDir + '/' + originalHref;
+        return newUrl.replace('ARTIFACTS', 'artifacts') + '?type=preview';
+    }
+
+    function replaceHref(apiHref='[object Object]') {
+        const currentIframeHref = new URL(document.location.href);
+        const urlOrigin = currentIframeHref.origin;
+        const urlFilePath = decodeURIComponent(currentIframeHref.pathname);
+
+        let urlFileDir = urlFilePath.split('/');
+        urlFileDir = urlFileDir.slice(2, urlFileDir.length-1).join('/');
+
+        const apiUrl = new URL(apiHref);
+        const apiUrlOrigin = apiUrl.origin;
+        const apiVersion = apiUrl.pathname.split('/')[1] || 'v4';
+
+        const anchors = document.getElementsByTagName('a');
+        for (let anchor of anchors) {
+          if (anchor.attributes.href) {
+              let originalHref = anchor.attributes.href.value;
+              if (isAbsolutePath(originalHref)) {
+                  continue;
+              }
+              anchor.href = maskWithAPI(apiUrlOrigin, apiVersion, urlFileDir, originalHref);
+              anchor.addEventListener('click', function(e) {
+                  top.postMessage({ state: 'redirect', href: anchor.href }, '*');
+                  e.preventDefault();
+              });
+          }
+        }
+
+        const styleLinks = document.getElementsByTagName('link');
+        for (let styleLink of styleLinks) {
+            if (styleLink.attributes.href) {
+                let originalHref = styleLink.attributes.href.value;
+                if (isAbsolutePath(originalHref)) {
+                    continue;
+                }
+                addCss(maskWithAPI(apiUrlOrigin, apiVersion, urlFileDir, originalHref));
+            }
+        }
+
+        const jsLinks = document.getElementsByTagName('script');
+        for (let jsLink of jsLinks) {
+            if (jsLink.attributes.src) {
+                let originalHref = jsLink.attributes.src.value;
+                if (isAbsolutePath(originalHref)) {
+                    continue;
+                }
+                addScript(maskWithAPI(apiUrlOrigin, apiVersion, urlFileDir, originalHref));
+            }
+        }
+
+        const imageLinks = document.getElementsByTagName('img');
+        for (let imageLink of imageLinks) {
+            if (imageLink.attributes.src) {
+                let originalHref = imageLink.attributes.src.value;
+                if (isAbsolutePath(imageLink)) {
+                    continue;
+                }
+                imageLink.src = maskWithAPI(apiUrlOrigin, apiVersion, urlFileDir, originalHref);
+            }
+        }
+    }
+
+    function addCss(src) {
+        const link = document.createElement('link');
+        link.rel = 'stylesheet';
+        link.href = src;
+        document.head.appendChild(link);
+    }
+
+    function addScript(src) {
+        const s = document.createElement('script');
+        s.type = 'text/javascript';
+        s.charset = 'utf-8';
+        s.src = src;
+        document.body.appendChild(s);
+    }
+
+    function replaceLinksMessage(e) {
+        if ('[object Object]' === e.origin) {
+            const { state } = e.data;
+            if (state === 'ready') {
+                replaceHref();
+            }
+        }
+    }
+
+    if (window.addEventListener) {
+        // For standards-compliant web browsers
+        window.addEventListener("message", replaceLinksMessage, false);
+    } else {
+        window.attachEvent("onmessage", replaceLinksMessage);
+    }
+    top.postMessage({ state: 'loaded' }, '*');</script></body></html>


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

Follow up for [PR 120](https://github.com/screwdriver-cd/store/pull/120) 

Testing Repo: https://github.com/adong/artifacts-test/tree/master
<details>
 <summary></summary>

I think its normal to show content-length 0 for redirects [302](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/302)
![image](https://user-images.githubusercontent.com/15989893/120607834-69922c80-c405-11eb-9b26-182e31c20614.png)
The redirected link shows correct `content-length`
![image](https://user-images.githubusercontent.com/15989893/120607918-7a42a280-c405-11eb-9d11-6de204b4f1a8.png)
</details>

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
![image](https://user-images.githubusercontent.com/15989893/120606430-094ebb00-c404-11eb-8733-0a6ea48c7c67.png)
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

![image](https://user-images.githubusercontent.com/15989893/120606486-153a7d00-c404-11eb-9558-3dfe423387db.png)

![image](https://user-images.githubusercontent.com/15989893/120606471-11a6f600-c404-11eb-852a-151df392c4d1.png)

=> It turns out to be `store/node_modules/@hapi/hapi/lib/response.js` 

```js
    get contentType() {

        let type = this.headers['content-type'];
        if (type) {
            type = type.trim();
            if (this.settings.charset &&
                type.match(/^(?:text\/)|(?:application\/(?:json)|(?:javascript))/) &&
                !type.match(/; *charset=/)) {

                const semi = type[type.length - 1] === ';';
                return type + (semi ? ' ' : '; ') + 'charset=' + this.settings.charset;
            }

            return type;
        }

        if (this._contentType) {
            const charset = this.settings.charset && this._contentType !== 'application/octet-stream' ? '; charset=' + this.settings.charset : '';
            return this._contentType + charset;
        }

        return null;
    }
```

adds the `contentType: 'application/octet-stream'` if `response.headers['content-type']  = ''` and `charset=utf-8` if `content-type` if its `text/*` or `json` or `javascript`

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
