### PR TITLE
fix: remove hard coded mappings and override mime-types library for new extensions

### DIFF
--- a/helpers/mime.js
+++ b/helpers/mime.js
@@ -2,19 +2,25 @@
 
 const mime = require('mime-types');
 
+mime.types.xml = 'text/xml';
+
 const FORCE_EXTENSION_MAPPING = {
     yidf: 'txt',
     state: 'txt',
-    diff: 'txt',
-    xml: 'txt' // FIXME: Chrome is not displaying xml files
+    diff: 'txt'
 };
 
 /**
  * getMimeFromFileExtension
  * @param  {String} fileExtension  File extension (e.g. css, txt, html)
+ * @param {String} fileName File name (e.g. dockerfile, main)
  * @return {String} text/html
  */
-function getMimeFromFileExtension(fileExtension) {
+function getMimeFromFileExtension(fileExtension, fileName = '') {
+    if (fileName.toLowerCase().endsWith('file')) {
+        return 'text/plain';
+    }
+
     return mime.lookup(FORCE_EXTENSION_MAPPING[fileExtension] || fileExtension) || '';
 }
 

--- a/helpers/mime.js
+++ b/helpers/mime.js
@@ -3,12 +3,9 @@
 const mime = require('mime-types');
 
 mime.types.xml = 'text/xml';
-
-const FORCE_EXTENSION_MAPPING = {
-    yidf: 'txt',
-    state: 'txt',
-    diff: 'txt'
-};
+['yidf', 'state', 'diff'].forEach((ext) => {
+    mime.types[ext] = 'text/plain';
+});
 
 /**
  * getMimeFromFileExtension
@@ -21,7 +18,7 @@ function getMimeFromFileExtension(fileExtension, fileName = '') {
         return 'text/plain';
     }
 
-    return mime.lookup(FORCE_EXTENSION_MAPPING[fileExtension] || fileExtension) || '';
+    return mime.lookup(fileExtension) || '';
 }
 
 const knownMimes = ['text/css', 'text/javascript', 'image/png', 'image/jpeg', 'application/json',

--- a/helpers/mime.js
+++ b/helpers/mime.js
@@ -21,12 +21,9 @@ function getMimeFromFileExtension(fileExtension, fileName = '') {
     return mime.lookup(fileExtension) || '';
 }
 
-const knownMimes = ['text/css', 'text/javascript', 'image/png', 'image/jpeg', 'application/json',
-    'text/plain', 'application/xml', 'text/yaml'];
 const displayableMimes = ['text/html'];
 
 module.exports = {
     getMimeFromFileExtension,
-    displayableMimes,
-    knownMimes
+    displayableMimes
 };

--- a/plugins/builds.js
+++ b/plugins/builds.js
@@ -97,7 +97,7 @@ exports.plugin = {
 
                 const fileName = artifact.split('/').pop();
                 const fileExt = fileName.split('.').pop();
-                const mime = getMimeFromFileExtension(fileExt);
+                const mime = getMimeFromFileExtension(fileExt, fileName);
 
                 // only if the artifact is requested as downloadable item
                 if (request.query.type === 'download') {
@@ -120,7 +120,7 @@ exports.plugin = {
                         $('body').append(scriptNode);
                         response = h.response($.html());
                         response.headers['content-type'] = mime;
-                    } else if (knownMimes.includes(mime)) {
+                    } else if (mime) {
                         response.headers['content-type'] = mime;
                     }
                 }

--- a/plugins/builds.js
+++ b/plugins/builds.js
@@ -8,7 +8,7 @@ const cheerio = require('cheerio');
 const AwsClient = require('../helpers/aws');
 const { iframeScript } = require('../helpers/iframe');
 const { streamToBuffer } = require('../helpers/helper');
-const { getMimeFromFileExtension, displayableMimes, knownMimes } = require('../helpers/mime');
+const { getMimeFromFileExtension, displayableMimes } = require('../helpers/mime');
 
 const SCHEMA_BUILD_ID = joi.number().integer().positive().label('Build ID');
 const SCHEMA_ARTIFACT_ID = joi.string().label('Artifact ID');


### PR DESCRIPTION
## Context

This is an extension of https://github.com/screwdriver-cd/store/pull/121

Been using https://github.com/adong/artifacts-test for testing. 

Chrome displays much more programming language files by default.

`xml` in chrome is a bit weird, since it displayed parsed file

<img width="1438" alt="Screen Shot 2021-06-03 at 1 53 58 PM" src="https://user-images.githubusercontent.com/193126/120710770-659cf380-c473-11eb-95e7-383d0da0381e.png">


## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
