### PR TITLE
fix: return content length for artifacts when using S3

### DIFF
--- a/plugins/builds.js
+++ b/plugins/builds.js
@@ -63,8 +63,13 @@ exports.plugin = {
                 // for old json files, the value is hidden in an object, we cannot stream it directly
                 if (usingS3) {
                     try {
-                        value = await awsClient.getDownloadStream({ cacheKey: id });
+                        const { s3Stream, s3Headers } =
+                            await awsClient.getDownloadStream({ cacheKey: id });
+
+                        value = s3Stream;
+
                         response = h.response(value);
+                        response.headers['content-length'] = s3Headers['content-length'];
                         isStreamOutput = true;
                     } catch (err) {
                         request.log([id, 'error'], `Failed to stream the cache: ${err}`);

--- a/plugins/caches.js
+++ b/plugins/caches.js
@@ -91,7 +91,9 @@ exports.plugin = {
                 // for old json files, the value is hidden in an object, we cannot stream it directly
                 if (usingS3 && cacheName.endsWith('.zip')) {
                     try {
-                        value = await awsClient.getDownloadStream({ cacheKey });
+                        const { s3Stream } = await awsClient.getDownloadStream({ cacheKey });
+
+                        value = s3Stream;
                         response = h.response(value);
                         response.headers['content-type'] = 'application/octet-stream';
                     } catch (err) {

--- a/test/helpers/aws.test.js
+++ b/test/helpers/aws.test.js
@@ -208,7 +208,7 @@ describe('aws helper test', () => {
         }, 0);
 
         return awsClient.getDownloadStream({ cacheKey })
-            .then((data) => {
+            .then(({ s3Stream: data }) => {
                 assert.calledWith(clientMock.prototype.getObject, getParam);
                 assert.isTrue(data instanceof TestStream);
             });

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -450,7 +450,7 @@ describe('builds plugin test using s3', () => {
             })
         };
 
-        getDownloadStreamMock = sinon.stub().resolves(null);
+        getDownloadStreamMock = sinon.stub().resolves({ s3Stream: {}, s3Headers: {} });
         uploadAsStreamMock = sinon.stub().resolves(null);
 
         awsClientMock = sinon.stub().returns({
@@ -525,7 +525,7 @@ describe('builds plugin test using s3', () => {
                 assert.calledWith(getDownloadStreamMock, {
                     cacheKey: `${mockBuildID}-foo.zip`
                 });
-                assert.equal(response.statusCode, 204);
+                assert.equal(response.statusCode, 200);
             })
         ));
 
@@ -595,7 +595,7 @@ describe('builds plugin test using s3', () => {
                 }
             });
 
-            assert.equal(downloadResponse.statusCode, 204);
+            assert.equal(downloadResponse.statusCode, 200);
             assert.equal(downloadResponse.headers['content-type'], 'application/octet-stream');
             assert.isNotOk(downloadResponse.headers['x-foo']);
             assert.isNotOk(downloadResponse.headers.ignore);

--- a/test/plugins/caches.test.js
+++ b/test/plugins/caches.test.js
@@ -784,7 +784,7 @@ describe('caches plugin test using s3', () => {
             })
         };
 
-        getDownloadStreamMock = sinon.stub().resolves(null);
+        getDownloadStreamMock = sinon.stub().resolves({ s3Stream: {}, s3Headers: {} });
         uploadAsStreamMock = sinon.stub().resolves(null);
         invalidateCacheMock = sinon.stub().yields(null);
 
@@ -842,7 +842,7 @@ describe('caches plugin test using s3', () => {
     });
 
     describe('GET /caches/events/:id/:cacheName', () => {
-        it('returns 204', () => (
+        it('returns 200', () => (
             server.inject({
                 headers: {
                     'x-foo': 'bar'
@@ -859,7 +859,7 @@ describe('caches plugin test using s3', () => {
                 assert.calledWith(getDownloadStreamMock, {
                     cacheKey: `events/${mockEventID}/foo.zip`
                 });
-                assert.equal(response.statusCode, 204);
+                assert.equal(response.statusCode, 200);
             })
         ));
 
@@ -928,7 +928,7 @@ describe('caches plugin test using s3', () => {
                     }
                 }
             }).then((getResponse) => {
-                assert.equal(getResponse.statusCode, 204);
+                assert.equal(getResponse.statusCode, 200);
                 assert.equal(getResponse.headers['content-type'], 'application/octet-stream');
                 assert.isNotOk(getResponse.headers['x-foo']);
                 assert.isNotOk(getResponse.headers.ignore);


### PR DESCRIPTION
## Context

API is not returning Content-Length header when using s3. This causes large file downloads to wait indefinitely without any visuals on when it will complete. 

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
