### PR TITLE
fix(1961): Remove request package

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,10 +75,9 @@
     "catbox-s3": "^4.0.0",
     "config": "^1.30.0",
     "hapi-auth-jwt2": "^10.1.0",
-    "hapi-swagger": "^14.0.0",
+    "hapi-swagger": "^14.2.4",
     "joi": "^17.2.0",
     "mime-types": "^2.1.25",
-    "request": "^2.88.0",
     "screwdriver-data-schema": "^21.0.0",
     "screwdriver-logger": "^1.0.0"
   }


### PR DESCRIPTION
## Context

Request package is deprecated.

## Objective

This PR removes the unused request package from the package.json.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1961

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
