### PR TITLE
fix(1500): Enable to Upload and Download artifact files by unzip worker scope token

### DIFF
--- a/plugins/builds.js
+++ b/plugins/builds.js
@@ -117,7 +117,7 @@ exports.plugin = {
                     tags: ['api', 'builds'],
                     auth: {
                         strategies: ['token'],
-                        scope: ['user', 'pipeline', 'build']
+                        scope: ['user', 'pipeline', 'build', 'unzip_worker']
                     },
                     plugins: {
                         'hapi-swagger': {
@@ -210,7 +210,7 @@ exports.plugin = {
                     },
                     auth: {
                         strategies: ['token'],
-                        scope: ['build']
+                        scope: ['build', 'unzip_worker']
                     },
                     plugins: {
                         'hapi-swagger': {


### PR DESCRIPTION
## Context
Allow `unzip_worker` scope token for `GET /v1/builds/{id}/{artifacts*}` and `PUT /v1/builds/{id}/{artifacts*}`.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
- Allow `unzip_worker` scope in builds plugin
- Add test cases to verify that `unzip_worker` scope token can be used
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/1500
https://github.com/screwdriver-cd/screwdriver/pull/2583
https://github.com/screwdriver-cd/queue-service/pull/37
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
