### PR TITLE
fix: fix strategy map on server start

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -7,17 +7,17 @@ const config = require('config');
 
 // Setup Caching strategy
 const strategyConfig = config.get('strategy');
+const { Engine: CatboxMemory } = require('@hapi/catbox-memory');
+const CatboxDisk = require('catbox-disk');
+const CatboxS3 = require('catbox-s3');
 const strategyMap = new Map([
-    ['memory', '@hapi/catbox-memory'],
-    ['disk', 'catbox-disk'],
-    ['s3', 'catbox-s3']
+    ['memory', CatboxMemory],
+    ['disk', CatboxDisk],
+    ['s3', CatboxS3]
 ]);
 const strategyModule = strategyMap.get(strategyConfig.plugin);
-
-// eslint-disable-next-line import/no-dynamic-require
-const strategy = require(strategyModule);
 const cache = {
-    engine: new strategy({
+    engine: new strategyModule({
         ...strategyConfig[strategyConfig.plugin]
     })
 };


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
when using memory strategy, it throws `TypeError: strategy is not a constructor` because of `@hapi/catbox-memory` dependency update
## Objective
fix syntax error
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
