### PR TITLE
fix: set ALLOW_CONFIG_MUTATIONS env

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -3,7 +3,7 @@
 'use strict';
 
 const logger = require('screwdriver-logger');
-// this env is needed to allow mutation of strategyConfig
+// this env is needed to allow modification of loaded configs
 // https://github.com/node-config/node-config/wiki/Environment-Variables#allow_config_mutations
 process.env.ALLOW_CONFIG_MUTATIONS = 'true';
 const config = require('config');

--- a/bin/server
+++ b/bin/server
@@ -3,6 +3,9 @@
 'use strict';
 
 const logger = require('screwdriver-logger');
+// this env is needed to allow mutation of strategyConfig
+// https://github.com/node-config/node-config/wiki/Environment-Variables#allow_config_mutations
+process.env.ALLOW_CONFIG_MUTATIONS = 'true';
 const config = require('config');
 
 // Setup Caching strategy


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
currently we modifies configs after they are loaded, `config` dependency throws error when we try to modify the conifg
## Objective
set `ALLOW_CONFIG_MUTATIONS` so `config` doesn't throw error
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
