### PR TITLE
fix: Command upload to process using stream

### DIFF
--- a/plugins/commands.js
+++ b/plugins/commands.js
@@ -125,7 +125,7 @@ exports.plugin = {
 
                     try {
                         if (usingS3) {
-                            await awsClient.uploadAsBuffer({ payload: contents, objectKey: id });
+                            await awsClient.uploadCommandAsStream({ payload: request.payload, cacheKey: id });
                         } else {
                             await cache.set(id, contents, 0);
                         }

--- a/test/helpers/aws.test.js
+++ b/test/helpers/aws.test.js
@@ -178,18 +178,16 @@ describe('aws helper test', () => {
         });
     });
 
-    it('upload commands directly', () => {
-        awsClient.segment = 'commands';
+    it('upload command as stream', () => {
         const uploadParam = {
             Bucket: testBucket,
-            Key: `commands/${objectKey}`
+            Key: `caches/${cacheKey}`
         };
         const uploadOption = {
             partSize
         };
 
-        // eslint-disable-next-line new-cap
-        return awsClient.uploadAsBuffer({ payload: Buffer.from('hello world', 'utf8'), objectKey }).then(() => {
+        return awsClient.uploadCommandAsStream({ cacheKey, payload: Buffer.from('hellow world', 'utf8') }).then(() => {
             assert.calledWith(clientMock.prototype.upload, sinon.match(uploadParam), sinon.match(uploadOption));
         });
     });

--- a/test/plugins/commands.test.js
+++ b/test/plugins/commands.test.js
@@ -325,7 +325,8 @@ describe('commands plugin test using s3', () => {
             getDownloadStream: getDownloadStreamMock,
             uploadCmdAsStream: uploadAsStreamMock,
             getDownloadObject: getDownloadMock,
-            uploadAsBuffer: uploadDirectMock
+            uploadAsBuffer: uploadDirectMock,
+            uploadCommandAsStream: uploadDirectMock
         });
 
         data = {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
This PR will use Stream when uploading commands from store to Object Storage.
It is better to use Stream as well as Build log.
This is useful for uploading large commands.

The following PRs started using Stream processing. However, it has been reverted back to using Buffer.
https://github.com/screwdriver-cd/store/pull/111

Probably the previous fix caused an error when downloading the command.
The reason is that there was missing metadata in the upload.
If the metadata is missing, the json parse will fail at the following code.
https://github.com/screwdriver-cd/store/blob/f3ee5e810a95a4c0484948988b3a60f6388e8722/helpers/aws.js#L264

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This PR creates a new function.
The existing "uploadAsStream" function cannot be used in the command upload because it depends on multi-part-upload in the requestor.
The upload of the command is API -> Store is sent in Buffer format.


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->


## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
