### PR TITLE
fix(2889): allow to get mime type directly by adding raw flag

### DIFF
--- a/helpers/mime.js
+++ b/helpers/mime.js
@@ -32,11 +32,16 @@ const KNOWN_FILE_EXTS_IN_TEXT_FORMAT = [
 /**
  * Get MIME types from file name and file extension
  * @method getMimeFromFileName
- * @param  {String} fileExtension  File extension (e.g. css, txt, html)
- * @param  {String} fileName       File name      (e.g. dockerfile, main)
- * @return {String} MIME Type      eg. text/html, text/plain
+ * @param  {String}  fileExtension  File extension (e.g. css, txt, html)
+ * @param  {String}  fileName       File name      (e.g. dockerfile, main)
+ * @param  {Boolean} raw            raw data type  (e.g. application/javascript instead of text/javascript)
+ * @return {String}  MIME Type      eg. text/html, text/plain
  */
-function getMimeFromFileName(fileExtension, fileName = '') {
+function getMimeFromFileName(fileExtension, fileName = '', raw = false) {
+    if (raw === true) {
+        return mime.lookup(fileExtension) || '';
+    }
+
     if (fileName.toLowerCase().endsWith('file')) {
         return 'text/plain';
     }

--- a/plugins/builds.js
+++ b/plugins/builds.js
@@ -113,7 +113,7 @@ exports.plugin = {
 
                         if (!displayableMimes.includes(mime)) {
                             response.headers['content-disposition'] = `inline; filename="${encodeURI(fileName)}"`;
-                        } 
+                        }
                     }
 
                     return response;

--- a/plugins/builds.js
+++ b/plugins/builds.js
@@ -104,6 +104,16 @@ exports.plugin = {
                         if (!displayableMimes.includes(mime)) {
                             response.headers['content-disposition'] = `inline; filename="${encodeURI(fileName)}"`;
                         }
+                    } else {
+                        const fileExt = fileName.split('.').pop();
+                        const raw = true;
+                        const mime = getMimeFromFileName(fileExt, fileName, raw);
+
+                        response.headers['content-type'] = mime;
+
+                        if (!displayableMimes.includes(mime)) {
+                            response.headers['content-disposition'] = `inline; filename="${encodeURI(fileName)}"`;
+                        } 
                     }
 
                     return response;

--- a/test/plugins/builds.test.js
+++ b/test/plugins/builds.test.js
@@ -308,7 +308,7 @@ describe('builds plugin test', () => {
 
             assert.equal(getResponse.statusCode, 200);
             assert.equal(getResponse.headers['x-foo'], 'bar');
-            assert.equal(getResponse.headers['content-type'], 'application/x-ndjson');
+            assert.equal(getResponse.headers['content-type'], 'application/octet-stream');
             assert.isNotOk(getResponse.headers.ignore);
             assert.equal(getResponse.result, 'THIS IS A TEST');
 
@@ -330,7 +330,7 @@ describe('builds plugin test', () => {
         it('saves an artifact of Japanese filename', async () => {
             options.url = `/builds/${mockBuildID}/日本語.txt`;
 
-            options.headers['content-type'] = 'application/x-ndjson';
+            options.headers['content-type'] = 'text/plain; charset=utf-8';
             const putResponse = await server.inject(options);
 
             assert.equal(putResponse.statusCode, 202);
@@ -348,7 +348,7 @@ describe('builds plugin test', () => {
 
             assert.equal(getResponse.statusCode, 200);
             assert.equal(getResponse.headers['x-foo'], 'bar');
-            assert.equal(getResponse.headers['content-type'], 'application/x-ndjson');
+            assert.equal(getResponse.headers['content-type'], 'text/plain; charset=utf-8');
             assert.isNotOk(getResponse.headers.ignore);
             assert.equal(getResponse.result, 'THIS IS A TEST');
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Related to issue https://github.com/screwdriver-cd/screwdriver/issues/2889,

For PR https://github.com/screwdriver-cd/screwdriver/pull/2888, after relaxing the backend, we run into an issue that 

```
module script but the server responded with a MIME type of "text/plain". 
Strict MIME type checking is enforced for module scripts per HTML spec.
```

![image](https://github.com/screwdriver-cd/store/assets/15989893/d0b66795-fae8-4a10-a9a0-3c3254fdbbb8)

## Objective

This PR adds more support besides, `download`, `preview` and raw mime type from the library itself.

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2889
## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
