### PR TITLE
fix(3062): use dumb-init instead of tini and register the shutdown plugin to hap…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,11 +17,10 @@ RUN ln -s /usr/src/app/node_modules/screwdriver-store/config /config
 # Expose the web service port
 EXPOSE 80
 
-# Add Tini
-ENV TINI_VERSION v0.19.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
-RUN chmod +x /tini
-ENTRYPOINT ["/tini", "--"]
+# Add dumb-init
+RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_x86_64
+RUN chmod +x /usr/local/bin/dumb-init
+ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
 
 # Run the service
 CMD [ "node", "./bin/server" ]

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -14,5 +14,10 @@ COPY . /usr/src/app
 # Expose the web service port
 EXPOSE 80
 
+# Add dumb-init
+RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_x86_64
+RUN chmod +x /usr/local/bin/dumb-init
+ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
+
 # Run the service
-CMD [ "npm", "start" ]
+CMD [ "node", "./bin/server" ]

--- a/lib/server.js
+++ b/lib/server.js
@@ -7,7 +7,8 @@ const CORE_PLUGINS = [
     '../plugins/status',
     '../plugins/swagger',
     '../plugins/logging',
-    '../plugins/stats'
+    '../plugins/stats',
+    '../plugins/shutdown'
 ];
 const CUSTOM_PLUGINS = ['auth', 'builds', 'commands', 'caches'];
 


### PR DESCRIPTION
…i-server


## Context
In [the previous PR](https://github.com/screwdriver-cd/screwdriver/pull/3063), we have fixed the Dockerfile to use `tini`  to handle sigterm appropriately for graceful shutdown. However it seems there are some issues for signal TRAP with `tini` as [this comment](https://github.com/screwdriver-cd/screwdriver/pull/3063#issuecomment-2025390989) mentioned.

And also the graceful-shutdown doesn't worked yet because [the shutdown plugin](https://github.com/screwdriver-cd/screwdriver/blob/master/plugins/shutdown.js) hasn't been registered.

## Objective
- Switches `tini` to `dumb-init` for the init process in the container as same as `launcher` does.
- Registers [the shutdown plugin](https://github.com/screwdriver-cd/screwdriver/blob/master/plugins/shutdown.js) to hapi-server for graceful shutdown

## References
[issue](https://github.com/screwdriver-cd/screwdriver/issues/3062)
[original comment](https://github.com/screwdriver-cd/screwdriver/pull/3063#issuecomment-2025390989)

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
