### PR TITLE
feat: Replace jwt expiration with a config and environment variable

### DIFF
--- a/config/custom-environment-variables.yaml
+++ b/config/custom-environment-variables.yaml
@@ -4,6 +4,7 @@
 auth:
     # A public key for verifying JWTs signed by api.screwdriver.cd
     jwtPublicKey: SECRET_JWT_PUBLIC_KEY
+    jwtMaxAge: JWT_MAX_AGE
 
 httpd:
     # Port to listen on

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -6,6 +6,7 @@ auth:
         -----BEGIN PUBLIC KEY-----
         INSERT STUFF HERE
         -----END PUBLIC KEY-----
+    jwtMaxAge: 13h
 
 httpd:
     # Port to listen on

--- a/plugins/auth.js
+++ b/plugins/auth.js
@@ -29,7 +29,8 @@ exports.plugin = {
         const pluginOptions = joi.attempt(
             options,
             joi.object().keys({
-                jwtPublicKey: joi.string().required()
+                jwtPublicKey: joi.string().required(),
+                jwtMaxAge: joi.string().required()
             }),
             'Invalid config for auth plugin'
         );
@@ -40,7 +41,7 @@ exports.plugin = {
             key: pluginOptions.jwtPublicKey,
             verifyOptions: {
                 algorithms: ['RS256'],
-                maxAge: '13h'
+                maxAge: pluginOptions.jwtMaxAge
             },
             // This function is run once the Token has been decoded with signature
             validate

--- a/test/lib/server.test.js
+++ b/test/lib/server.test.js
@@ -39,7 +39,8 @@ describe('server case', function () {
                         engine: new Catbox()
                     },
                     auth: {
-                        jwtPublicKey: '12345'
+                        jwtPublicKey: '12345',
+                        jwtMaxAge: '1h'
                     },
                     commands: {},
                     ecosystem,


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
The jwt expiration is currently 13h and is written directly in the source code.
This makes it difficult for SD administrators to change to arbitrary values to suit their use cases.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Can be configured from config file or environment variable.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/guide/pull/600

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
