### PR TITLE
feat(3013): Add handling for the Expect header at onPreAuth

### DIFF
--- a/plugins/caches.js
+++ b/plugins/caches.js
@@ -305,9 +305,9 @@ exports.plugin = {
                                             options.maxByteSize
                                         );
                                         throw boom.entityTooLarge();
-                                    } else {
-                                        request.raw.res.writeContinue();
                                     }
+
+                                    request.raw.res.writeContinue();
                                 }
 
                                 return h.continue;

--- a/plugins/caches.js
+++ b/plugins/caches.js
@@ -372,6 +372,26 @@ exports.plugin = {
                             id: SCHEMA_SCOPE_ID,
                             cacheName: SCHEMA_CACHE_NAME
                         })
+                    },
+                    ext: {
+                        onPreAuth: {
+                            method: (request, h) => {
+                                const contentLength = request.headers['Content-Length'];
+                                const expectHeader = request.headers.expect;
+
+                                if (expectHeader && expectHeader.toLowerCase() === '100-continue') {
+                                    if (contentLength && parseInt(contentLength, 10) > options.maxByteSize) {
+                                        throw boom.entityTooLarge(
+                                            `Payload content length greater than maximum allowed: ${options.maxByteSize}`
+                                        );
+                                    } else {
+                                        return h.response().code(100).takeover();
+                                    }
+                                }
+
+                                return h.continue;
+                            }
+                        }
                     }
                 }
             },

--- a/plugins/caches.js
+++ b/plugins/caches.js
@@ -291,6 +291,26 @@ exports.plugin = {
                             id: SCHEMA_SCOPE_ID,
                             cacheName: SCHEMA_CACHE_NAME
                         })
+                    },
+                    ext: {
+                        onPreAuth: {
+                            method: (request, h) => {
+                                const contentLength = request.headers['Content-Length'];
+                                const expectHeader = request.headers.expect;
+
+                                if (expectHeader && expectHeader.toLowerCase() === '100-continue') {
+                                    if (contentLength && parseInt(contentLength, 10) > options.maxByteSize) {
+                                        throw boom.entityTooLarge(
+                                            `Payload content length greater than maximum allowed: ${options.maxByteSize}`
+                                        );
+                                    } else {
+                                        request.raw.res.writeContinue();
+                                    }
+                                }
+
+                                return h.continue;
+                            }
+                        }
                     }
                 }
             },
@@ -372,26 +392,6 @@ exports.plugin = {
                             id: SCHEMA_SCOPE_ID,
                             cacheName: SCHEMA_CACHE_NAME
                         })
-                    },
-                    ext: {
-                        onPreAuth: {
-                            method: (request, h) => {
-                                const contentLength = request.headers['Content-Length'];
-                                const expectHeader = request.headers.expect;
-
-                                if (expectHeader && expectHeader.toLowerCase() === '100-continue') {
-                                    if (contentLength && parseInt(contentLength, 10) > options.maxByteSize) {
-                                        throw boom.entityTooLarge(
-                                            `Payload content length greater than maximum allowed: ${options.maxByteSize}`
-                                        );
-                                    } else {
-                                        return h.response().code(100).takeover();
-                                    }
-                                }
-
-                                return h.continue;
-                            }
-                        }
                     }
                 }
             },

--- a/plugins/caches.js
+++ b/plugins/caches.js
@@ -295,14 +295,16 @@ exports.plugin = {
                     ext: {
                         onPreAuth: {
                             method: (request, h) => {
-                                const contentLength = request.headers['Content-Length'];
+                                const contentLength = request.headers['content-length'];
                                 const expectHeader = request.headers.expect;
 
                                 if (expectHeader && expectHeader.toLowerCase() === '100-continue') {
                                     if (contentLength && parseInt(contentLength, 10) > options.maxByteSize) {
-                                        throw boom.entityTooLarge(
-                                            `Payload content length greater than maximum allowed: ${options.maxByteSize}`
+                                        request.log(
+                                            'Payload content length greater than maximum allowed',
+                                            options.maxByteSize
                                         );
+                                        throw boom.entityTooLarge();
                                     } else {
                                         request.raw.res.writeContinue();
                                     }


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

I would like to reduce unnecessary retries when uploading large files.
By using the `Expect: 100-continue` header, the content length can be checked before the body is uploaded.
Thus, the HTTP client (store-cli) can receive a 413 error earlier without unnecessary retries.

I have also submitted a related PR to `store-cli`.

https://github.com/screwdriver-cd/store-cli/pull/82

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
To reduce unnecessary retries, return a 413 error earlier.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
[issue](https://github.com/screwdriver-cd/screwdriver/issues/3013)
[store-cli](https://github.com/screwdriver-cd/store-cli/pull/82)

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
