### PR TITLE
fix: enforce command ownership on store POST/DELETE

### DIFF
--- a/plugins/commands.js
+++ b/plugins/commands.js
@@ -1,5 +1,7 @@
 'use strict';
 
+/* global globalThis */
+
 const joi = require('joi');
 const boom = require('@hapi/boom');
 const schema = require('screwdriver-data-schema');
@@ -10,6 +12,43 @@ const DEFAULT_TTL = 24 * 60 * 60 * 1000; // 1 day
 const DEFAULT_BYTES = 1024 * 1024 * 1024; // 1GB
 const config = require('config');
 const AwsClient = require('../helpers/aws');
+
+/**
+ * Look up the authoritative owning pipelineId for a command from the API.
+ *
+ * Command binaries are fetched by builds directly from the store, so the store
+ * cannot rely on the API's route-level ownership check. This consults the
+ * command's API record (which carries the owning pipelineId) so the store can
+ * reject a mutation coming from a different pipeline.
+ * @method  getCommandOwner
+ * @param   {Object}  arg
+ * @param   {String}  arg.apiUrl         Base URL of the Screwdriver API
+ * @param   {String}  arg.namespace      Command namespace
+ * @param   {String}  arg.name           Command name
+ * @param   {String}  arg.version        Command version
+ * @param   {String}  arg.authorization  Authorization header to forward
+ * @returns {Promise<Number|null>}       Owning pipelineId, or null when the command has no record yet
+ */
+async function getCommandOwner({ apiUrl, namespace, name, version, authorization }) {
+    const response = await globalThis.fetch(`${apiUrl}/v1/commands/${namespace}/${name}/${version}`, {
+        method: 'GET',
+        headers: { authorization }
+    });
+
+    // No record yet — the command is unowned (e.g. first publish, before the
+    // API persists the record), so there is nothing to protect.
+    if (response.status === 404) {
+        return null;
+    }
+
+    if (response.status !== 200) {
+        throw new Error(`Command ownership lookup returned status ${response.status}`);
+    }
+
+    const command = await response.json();
+
+    return command.pipelineId;
+}
 
 exports.plugin = {
     name: 'commands',
@@ -123,6 +162,33 @@ exports.plugin = {
                             `bytes with headers ${JSON.stringify(contents.h)}`
                     );
 
+                    // Reject an overwrite of a command owned by a different
+                    // pipeline. Builds reach this route directly (bypassing the
+                    // API's ownership check), so the store must verify ownership
+                    // against the command's authoritative API record.
+                    const apiUrl = config.get('ecosystem').api;
+
+                    if (apiUrl) {
+                        let ownerPipelineId;
+
+                        try {
+                            ownerPipelineId = await getCommandOwner({
+                                apiUrl,
+                                namespace,
+                                name,
+                                version,
+                                authorization: request.headers.authorization
+                            });
+                        } catch (err) {
+                            request.log([id, 'error'], `Failed to verify command ownership: ${err}`);
+                            throw boom.serverUnavailable('Failed to verify command ownership');
+                        }
+
+                        if (ownerPipelineId !== null && ownerPipelineId !== pipelineId) {
+                            throw boom.forbidden('Not allowed to overwrite this command');
+                        }
+                    }
+
                     try {
                         if (usingS3) {
                             await awsClient.uploadCommandAsStream({ payload: request.payload, cacheKey: id });
@@ -166,8 +232,36 @@ exports.plugin = {
                 method: 'DELETE',
                 path: '/commands/{namespace}/{name}/{version}',
                 handler: async (request, h) => {
+                    const { pipelineId } = request.auth.credentials;
                     const { namespace, name, version } = request.params;
                     const id = `${namespace}-${name}-${version}`;
+
+                    // Build credentials carry a pipelineId; reject a delete of a
+                    // command owned by a different pipeline. User-scope deletes
+                    // arrive via the API, which authorizes them before
+                    // forwarding here and carry no pipelineId.
+                    const apiUrl = config.get('ecosystem').api;
+
+                    if (apiUrl && pipelineId !== undefined && pipelineId !== null) {
+                        let ownerPipelineId;
+
+                        try {
+                            ownerPipelineId = await getCommandOwner({
+                                apiUrl,
+                                namespace,
+                                name,
+                                version,
+                                authorization: request.headers.authorization
+                            });
+                        } catch (err) {
+                            request.log([id, 'error'], `Failed to verify command ownership: ${err}`);
+                            throw boom.serverUnavailable('Failed to verify command ownership');
+                        }
+
+                        if (ownerPipelineId !== null && ownerPipelineId !== pipelineId) {
+                            throw boom.forbidden('Not allowed to delete this command');
+                        }
+                    }
 
                     try {
                         if (usingS3) {

--- a/plugins/commands.js
+++ b/plugins/commands.js
@@ -10,6 +10,7 @@ const SCHEMA_COMMAND_NAME = schema.config.command.name;
 const SCHEMA_COMMAND_VERSION = schema.config.command.version;
 const DEFAULT_TTL = 24 * 60 * 60 * 1000; // 1 day
 const DEFAULT_BYTES = 1024 * 1024 * 1024; // 1GB
+const OWNERSHIP_LOOKUP_TIMEOUT_MS = 10 * 1000; // bound the API round-trip so a slow API fails closed promptly
 const config = require('config');
 const AwsClient = require('../helpers/aws');
 
@@ -32,7 +33,9 @@ const AwsClient = require('../helpers/aws');
 async function getCommandOwner({ apiUrl, namespace, name, version, authorization }) {
     const response = await globalThis.fetch(`${apiUrl}/v1/commands/${namespace}/${name}/${version}`, {
         method: 'GET',
-        headers: { authorization }
+        headers: { authorization },
+        // A hung (not down) API would otherwise stall every write/delete; bound it.
+        signal: AbortSignal.timeout(OWNERSHIP_LOOKUP_TIMEOUT_MS)
     });
 
     // No record yet — the command is unowned (e.g. first publish, before the
@@ -48,6 +51,54 @@ async function getCommandOwner({ apiUrl, namespace, name, version, authorization
     const command = await response.json();
 
     return command.pipelineId;
+}
+
+/**
+ * Reject the request unless the caller's pipeline owns the target command.
+ *
+ * Fails closed: an unconfigured API URL, a lookup error, a timeout, or an
+ * owner mismatch all block the mutation rather than silently allowing it. A
+ * command with no API record yet (404) is treated as unowned so first
+ * publishes still succeed.
+ * @method  assertCommandOwnership
+ * @param   {Object}  arg
+ * @param   {Object}  arg.request        Hapi request (for auth header + logging)
+ * @param   {String}  arg.namespace      Command namespace
+ * @param   {String}  arg.name           Command name
+ * @param   {String}  arg.version        Command version
+ * @param   {Number}  arg.pipelineId     Owning pipelineId from the caller's credentials
+ * @param   {String}  arg.action         Verb for the forbidden message (e.g. 'overwrite', 'delete')
+ * @returns {Promise}
+ */
+async function assertCommandOwnership({ request, namespace, name, version, pipelineId, action }) {
+    const id = `${namespace}-${name}-${version}`;
+    const apiUrl = config.get('ecosystem').api;
+
+    if (!apiUrl) {
+        request.log([id, 'error'], 'Cannot verify command ownership: ecosystem.api is not configured');
+        throw boom.serverUnavailable('Command ownership verification is not configured');
+    }
+
+    let ownerPipelineId;
+
+    try {
+        ownerPipelineId = await getCommandOwner({
+            apiUrl,
+            namespace,
+            name,
+            version,
+            authorization: request.headers.authorization
+        });
+    } catch (err) {
+        request.log([id, 'error'], `Failed to verify command ownership: ${err}`);
+        throw boom.serverUnavailable('Failed to verify command ownership');
+    }
+
+    // Normalize both sides: the API body and the JWT credentials could carry
+    // the id as a number or a numeric string.
+    if (ownerPipelineId !== null && Number(ownerPipelineId) !== Number(pipelineId)) {
+        throw boom.forbidden(`Not allowed to ${action} this command`);
+    }
 }
 
 exports.plugin = {
@@ -166,28 +217,14 @@ exports.plugin = {
                     // pipeline. Builds reach this route directly (bypassing the
                     // API's ownership check), so the store must verify ownership
                     // against the command's authoritative API record.
-                    const apiUrl = config.get('ecosystem').api;
-
-                    if (apiUrl) {
-                        let ownerPipelineId;
-
-                        try {
-                            ownerPipelineId = await getCommandOwner({
-                                apiUrl,
-                                namespace,
-                                name,
-                                version,
-                                authorization: request.headers.authorization
-                            });
-                        } catch (err) {
-                            request.log([id, 'error'], `Failed to verify command ownership: ${err}`);
-                            throw boom.serverUnavailable('Failed to verify command ownership');
-                        }
-
-                        if (ownerPipelineId !== null && ownerPipelineId !== pipelineId) {
-                            throw boom.forbidden('Not allowed to overwrite this command');
-                        }
-                    }
+                    await assertCommandOwnership({
+                        request,
+                        namespace,
+                        name,
+                        version,
+                        pipelineId,
+                        action: 'overwrite'
+                    });
 
                     try {
                         if (usingS3) {
@@ -240,27 +277,15 @@ exports.plugin = {
                     // command owned by a different pipeline. User-scope deletes
                     // arrive via the API, which authorizes them before
                     // forwarding here and carry no pipelineId.
-                    const apiUrl = config.get('ecosystem').api;
-
-                    if (apiUrl && pipelineId !== undefined && pipelineId !== null) {
-                        let ownerPipelineId;
-
-                        try {
-                            ownerPipelineId = await getCommandOwner({
-                                apiUrl,
-                                namespace,
-                                name,
-                                version,
-                                authorization: request.headers.authorization
-                            });
-                        } catch (err) {
-                            request.log([id, 'error'], `Failed to verify command ownership: ${err}`);
-                            throw boom.serverUnavailable('Failed to verify command ownership');
-                        }
-
-                        if (ownerPipelineId !== null && ownerPipelineId !== pipelineId) {
-                            throw boom.forbidden('Not allowed to delete this command');
-                        }
+                    if (pipelineId !== undefined && pipelineId !== null) {
+                        await assertCommandOwnership({
+                            request,
+                            namespace,
+                            name,
+                            version,
+                            pipelineId,
+                            action: 'delete'
+                        });
                     }
 
                     try {

--- a/test/plugins/commands.test.js
+++ b/test/plugins/commands.test.js
@@ -18,6 +18,7 @@ describe('commands plugin test', () => {
     let plugin;
     let server;
     let configMock;
+    let fetchStub;
 
     before(() => {
         mockery.enable({
@@ -27,12 +28,13 @@ describe('commands plugin test', () => {
     });
 
     beforeEach(async () => {
-        configMock = {
-            get: sinon.stub().returns({
-                plugin: 'memory'
-            })
-        };
+        configMock = { get: sinon.stub() };
+        configMock.get.withArgs('strategy').returns({ plugin: 'memory' });
+        configMock.get.withArgs('ecosystem').returns({ api: 'https://api.test' });
         mockery.registerMock('config', configMock);
+
+        // Default: command is unowned (no API record) so writes/deletes are allowed.
+        fetchStub = sinon.stub(globalThis, 'fetch').resolves({ status: 404 });
 
         // eslint-disable-next-line global-require
         plugin = require('../../plugins/commands');
@@ -58,6 +60,7 @@ describe('commands plugin test', () => {
     afterEach(async () => {
         await server.stop();
         server = null;
+        fetchStub.restore();
         mockery.deregisterAll();
         mockery.resetCache();
     });
@@ -298,6 +301,7 @@ describe('commands plugin test using s3', () => {
     let uploadAsStreamMock;
     let deleteObjMock;
     let getDownloadMock;
+    let fetchStub;
     let data;
 
     before(() => {
@@ -308,12 +312,13 @@ describe('commands plugin test using s3', () => {
     });
 
     beforeEach(() => {
-        configMock = {
-            get: sinon.stub().returns({
-                plugin: 's3',
-                s3: {}
-            })
-        };
+        configMock = { get: sinon.stub() };
+        configMock.get.withArgs('strategy').returns({ plugin: 's3', s3: {} });
+        configMock.get.withArgs('ecosystem').returns({ api: 'https://api.test' });
+
+        // Default: command is unowned (no API record) so writes/deletes are allowed.
+        fetchStub = sinon.stub(globalThis, 'fetch').resolves({ status: 404 });
+
         getDownloadStreamMock = sinon.stub().resolves(null);
         uploadAsStreamMock = sinon.stub().resolves(null);
         deleteObjMock = sinon.stub().resolves(null);
@@ -353,6 +358,7 @@ describe('commands plugin test using s3', () => {
     afterEach(async () => {
         await server.stop();
         server = null;
+        fetchStub.restore();
         mockery.deregisterAll();
         mockery.resetCache();
     });
@@ -624,6 +630,23 @@ describe('commands plugin ownership enforcement', () => {
 
             return server.inject(postOptions()).then(response => {
                 assert.equal(response.statusCode, 503);
+            });
+        });
+
+        it('fails closed with 503 when ecosystem.api is not configured', () => {
+            configMock.get.withArgs('ecosystem').returns({});
+
+            return server.inject(postOptions()).then(response => {
+                assert.equal(response.statusCode, 503);
+                assert.notCalled(fetchStub);
+            });
+        });
+
+        it('allows the owner when the API returns pipelineId as a numeric string', () => {
+            fetchStub.resolves(ownerResponse('123'));
+
+            return server.inject(postOptions()).then(response => {
+                assert.equal(response.statusCode, 202);
             });
         });
     });

--- a/test/plugins/commands.test.js
+++ b/test/plugins/commands.test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+/* global globalThis */
+
 const { assert } = require('chai');
 const sinon = require('sinon');
 const Hapi = require('@hapi/hapi');
@@ -508,6 +510,156 @@ describe('commands plugin test using s3', () => {
             return server.inject(deleteOptions).then(deleteResponse => {
                 assert.equal(deleteResponse.statusCode, 204);
             });
+        });
+    });
+});
+
+describe('commands plugin ownership enforcement', () => {
+    const mockCommandNamespace = 'foo';
+    const mockCommandName = 'bar';
+    const mockCommandVersion = '1.2.3';
+    const apiUrl = 'https://api.test';
+    const commandUrl = `/commands/${mockCommandNamespace}/${mockCommandName}/${mockCommandVersion}`;
+    let plugin;
+    let server;
+    let configMock;
+    let fetchStub;
+
+    before(() => {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+    });
+
+    beforeEach(async () => {
+        configMock = { get: sinon.stub() };
+        configMock.get.withArgs('strategy').returns({ plugin: 'memory' });
+        configMock.get.withArgs('ecosystem').returns({ api: apiUrl });
+        mockery.registerMock('config', configMock);
+
+        fetchStub = sinon.stub(globalThis, 'fetch');
+
+        // eslint-disable-next-line global-require
+        plugin = require('../../plugins/commands');
+
+        server = Hapi.server({
+            cache: {
+                engine: new CatboxMemory({
+                    maxByteSize: 512
+                })
+            },
+            port: 1234
+        });
+        server.auth.scheme('custom', () => ({
+            authenticate: (request, h) => h.authenticated()
+        }));
+        server.auth.strategy('token', 'custom');
+
+        await server.register({ plugin });
+        await server.start();
+    });
+
+    afterEach(async () => {
+        await server.stop();
+        server = null;
+        fetchStub.restore();
+        mockery.deregisterAll();
+        mockery.resetCache();
+    });
+
+    after(() => {
+        mockery.disable();
+    });
+
+    const buildAuth = (pipelineId = 123) => ({
+        strategy: 'token',
+        credentials: {
+            scope: ['build'],
+            pipelineId
+        }
+    });
+
+    const ownerResponse = pipelineId => ({
+        status: 200,
+        json: () => Promise.resolve({ pipelineId })
+    });
+
+    describe('POST', () => {
+        const postOptions = () => ({
+            method: 'POST',
+            payload: 'THIS IS A TEST',
+            headers: { 'content-type': 'text/plain', authorization: 'Bearer token' },
+            auth: buildAuth(123),
+            url: commandUrl
+        });
+
+        it('returns 403 when the command is owned by a different pipeline', () => {
+            fetchStub.resolves(ownerResponse(999));
+
+            return server.inject(postOptions()).then(response => {
+                assert.equal(response.statusCode, 403);
+                assert.calledOnce(fetchStub);
+            });
+        });
+
+        it('returns 202 when the owning pipeline re-uploads', () => {
+            fetchStub.resolves(ownerResponse(123));
+
+            return server.inject(postOptions()).then(response => {
+                assert.equal(response.statusCode, 202);
+            });
+        });
+
+        it('returns 202 on first publish when no record exists yet', () => {
+            fetchStub.resolves({ status: 404 });
+
+            return server.inject(postOptions()).then(response => {
+                assert.equal(response.statusCode, 202);
+            });
+        });
+
+        it('returns 503 when the ownership lookup fails', () => {
+            fetchStub.resolves({ status: 500 });
+
+            return server.inject(postOptions()).then(response => {
+                assert.equal(response.statusCode, 503);
+            });
+        });
+    });
+
+    describe('DELETE', () => {
+        const deleteOptions = auth => ({
+            method: 'DELETE',
+            headers: { authorization: 'Bearer token' },
+            auth,
+            url: commandUrl
+        });
+
+        it("returns 403 when a build deletes another pipeline's command", () => {
+            fetchStub.resolves(ownerResponse(999));
+
+            return server.inject(deleteOptions(buildAuth(123))).then(response => {
+                assert.equal(response.statusCode, 403);
+                assert.calledOnce(fetchStub);
+            });
+        });
+
+        it('returns 204 when the owning pipeline deletes its command', () => {
+            fetchStub.resolves(ownerResponse(123));
+
+            return server.inject(deleteOptions(buildAuth(123))).then(response => {
+                assert.equal(response.statusCode, 204);
+            });
+        });
+
+        it('skips the ownership lookup for user-scope deletes', () => {
+            return server
+                .inject(deleteOptions({ strategy: 'token', credentials: { scope: ['user'] } }))
+                .then(response => {
+                    assert.equal(response.statusCode, 204);
+                    assert.notCalled(fetchStub);
+                });
         });
     });
 });


### PR DESCRIPTION
## Summary

**What changed**
- Writing (`POST`) or deleting (`DELETE`) a command binary now verifies that the caller owns the command before mutating it; a request from a different pipeline is rejected with `403`.
- Ownership is resolved by looking up the command's authoritative `pipelineId` from the API record (`GET /v1/commands/:namespace/:name/:version`, forwarding the caller's token) using native `fetch` — no new dependency.

**Why**
- Command binaries are uploaded to and fetched from the store directly by builds via `$SD_STORE_URL`, bypassing the API's per-namespace ownership check. The store performed no ownership check of its own, so any build-scope JWT could overwrite a command binary owned by another pipeline (a supply-chain vector into every consuming pipeline) or delete it (availability).


**Scope**
- `POST`: rejects a cross-pipeline overwrite; a missing API record (`404`) is treated as unowned so a first publish still succeeds.
- `DELETE`: enforced for build credentials (which carry a `pipelineId`); user-scope deletes continue to arrive via the API, which authorizes them first.
- The ownership lookup fails **closed** (`503`) so an API outage cannot re-open the hole.

## Spec updates
- N/A — no `docs/specs` in this repo.

## Example (before → after)

Pipeline B (`pipelineId=2002`) targeting a command owned by pipeline A (`pipelineId=1001`):

Before:
```
POST /v1/commands/shared-tools/deploy-tool/1.0.0   (Bearer build JWT, pipelineId=2002)
-> HTTP 202 Accepted        # binary silently overwritten
```

After:
```
POST /v1/commands/shared-tools/deploy-tool/1.0.0   (Bearer build JWT, pipelineId=2002)
-> HTTP 403 Forbidden       # "Not allowed to overwrite this command"
```

The owning pipeline's own publish/re-publish and first-time publishes are unaffected.

## Test plan
- [x] `npx mocha test/plugins/commands.test.js` — new ownership suite (403 cross-pipeline POST/DELETE, 202 owner re-upload, 202 first-publish 404, 503 lookup failure, user-scope skip) + existing cases pass (21 passing)
- [x] `npx mocha --recursive test/` — full suite green (110 passing)
- [x] `eslint .` — 0 errors

## Out of scope
- User-scope `DELETE` hardening at the store layer (currently authorized upstream by the API's SCM-admin check).
- The no-op `plugins/auth.js` `validate()` stub (broader auth hardening).